### PR TITLE
Load wallet in memory

### DIFF
--- a/bark-cpp/bark-cpp.h
+++ b/bark-cpp/bark-cpp.h
@@ -11,163 +11,171 @@
 #include <ostream>
 #include <new>
 
-namespace bark {
+namespace bark
+{
 
-enum class bark_BarkRefreshModeType {
-  DefaultThreshold,
-  ThresholdBlocks,
-  ThresholdHours,
-  Counterparty,
-  All,
-  Specific,
-};
+  enum class bark_BarkRefreshModeType
+  {
+    DefaultThreshold,
+    ThresholdBlocks,
+    ThresholdHours,
+    Counterparty,
+    All,
+    Specific,
+  };
 
-struct bark_BarkError {
-  char *message;
-};
+  struct bark_BarkError
+  {
+    char *message;
+  };
 
-struct bark_BarkConfigOpts {
-  const char *asp;
-  const char *esplora;
-  const char *bitcoind;
-  const char *bitcoind_cookie;
-  const char *bitcoind_user;
-  const char *bitcoind_pass;
-  uint32_t vtxo_refresh_expiry_threshold;
-  const uint64_t *fallback_fee_rate;
-};
+  struct bark_BarkConfigOpts
+  {
+    const char *asp;
+    const char *esplora;
+    const char *bitcoind;
+    const char *bitcoind_cookie;
+    const char *bitcoind_user;
+    const char *bitcoind_pass;
+    uint32_t vtxo_refresh_expiry_threshold;
+    const uint64_t *fallback_fee_rate;
+  };
 
-struct bark_BarkCreateOpts {
-  bool force;
-  bool regtest;
-  bool signet;
-  bool bitcoin;
-  const char *mnemonic;
-  uint32_t birthday_height;
-  bark_BarkConfigOpts config;
-};
+  struct bark_BarkCreateOpts
+  {
+    bool force;
+    bool regtest;
+    bool signet;
+    bool bitcoin;
+    const char *mnemonic;
+    uint32_t birthday_height;
+    bark_BarkConfigOpts config;
+  };
 
-struct bark_BarkBalance {
-  uint64_t onchain;
-  uint64_t offchain;
-  uint64_t pending_exit;
-};
+  struct bark_BarkBalance
+  {
+    uint64_t onchain;
+    uint64_t offchain;
+    uint64_t pending_exit;
+  };
 
-struct bark_BarkRefreshOpts {
-  bark_BarkRefreshModeType mode_type;
-  uint32_t threshold_value;
-  const char *const *specific_vtxo_ids;
-  uintptr_t num_specific_vtxo_ids;
-};
+  struct bark_BarkRefreshOpts
+  {
+    bark_BarkRefreshModeType mode_type;
+    uint32_t threshold_value;
+    const char *const *specific_vtxo_ids;
+    uintptr_t num_specific_vtxo_ids;
+  };
 
-extern "C" {
+  extern "C"
+  {
 
-/// Initializes the logger for the library.
-/// This should be called once when the library is loaded by the C/C++ application,
-/// before any other library functions are used.
-void bark_init_logger();
+    /// Initializes the logger for the library.
+    /// This should be called once when the library is loaded by the C/C++ application,
+    /// before any other library functions are used.
+    void bark_init_logger();
 
-void bark_free_error(bark_BarkError *error);
+    void bark_free_error(bark_BarkError *error);
 
-const char *bark_error_message(const bark_BarkError *error);
+    const char *bark_error_message(const bark_BarkError *error);
 
-/// Frees a C string allocated by a bark-cpp function.
-void bark_free_string(char *s);
+    /// Frees a C string allocated by a bark-cpp function.
+    void bark_free_string(char *s);
 
-/// Create a new mnemonic
-char *bark_create_mnemonic();
+    /// Create a new mnemonic
+    char *bark_create_mnemonic();
 
-/// Load an existing wallet or create a new one at the specified directory
-bark_BarkError *bark_load_wallet(const char *datadir, bark_BarkCreateOpts opts);
+    /// Load an existing wallet or create a new one at the specified directory
+    bark_BarkError *bark_load_wallet(const char *datadir, bark_BarkCreateOpts opts);
 
-/// Close the currently loaded wallet
-bark_BarkError *bark_close_wallet();
+    /// Close the currently loaded wallet
+    bark_BarkError *bark_close_wallet();
 
-/// Get offchain and onchain balances
-bark_BarkError *bark_get_balance(bool no_sync, bark_BarkBalance *balance_out);
+    /// Get offchain and onchain balances
+    bark_BarkError *bark_get_balance(bool no_sync, bark_BarkBalance *balance_out);
 
-/// Get an onchain address.
-bark_BarkError *bark_get_onchain_address(char **address_out);
+    /// Get an onchain address.
+    bark_BarkError *bark_get_onchain_address(char **address_out);
 
-/// Send funds using the onchain wallet.
-bark_BarkError *bark_send_onchain(const char *destination,
-                                  uint64_t amount_sat,
-                                  bool no_sync,
-                                  char **txid_out);
+    /// Send funds using the onchain wallet.
+    bark_BarkError *bark_send_onchain(const char *destination,
+                                      uint64_t amount_sat,
+                                      bool no_sync,
+                                      char **txid_out);
 
-/// Send all funds from the onchain wallet to a destination address.
-bark_BarkError *bark_drain_onchain(const char *destination, bool no_sync, char **txid_out);
+    /// Send all funds from the onchain wallet to a destination address.
+    bark_BarkError *bark_drain_onchain(const char *destination, bool no_sync, char **txid_out);
 
-/// Send funds to multiple recipients using the onchain wallet.
-bark_BarkError *bark_send_many_onchain(const char *const *destinations,
-                                       const uint64_t *amounts_sat,
-                                       uintptr_t num_outputs,
-                                       bool no_sync,
-                                       char **txid_out);
+    /// Send funds to multiple recipients using the onchain wallet.
+    bark_BarkError *bark_send_many_onchain(const char *const *destinations,
+                                           const uint64_t *amounts_sat,
+                                           uintptr_t num_outputs,
+                                           bool no_sync,
+                                           char **txid_out);
 
-/// Get the list of onchain UTXOs as a JSON string.
-bark_BarkError *bark_get_onchain_utxos(bool no_sync, char **utxos_json_out);
+    /// Get the list of onchain UTXOs as a JSON string.
+    bark_BarkError *bark_get_onchain_utxos(bool no_sync, char **utxos_json_out);
 
-/// Get the wallet's VTXO public key (hex string).
-bark_BarkError *bark_get_vtxo_pubkey(const uint32_t *index, char **pubkey_hex_out);
+    /// Get the wallet's VTXO public key (hex string).
+    bark_BarkError *bark_get_vtxo_pubkey(const uint32_t *index, char **pubkey_hex_out);
 
-/// Get the list of VTXOs as a JSON string.
-bark_BarkError *bark_get_vtxos(bool no_sync, char **vtxos_json_out);
+    /// Get the list of VTXOs as a JSON string.
+    bark_BarkError *bark_get_vtxos(bool no_sync, char **vtxos_json_out);
 
-/// Refresh VTXOs based on specified criteria.
-bark_BarkError *bark_refresh_vtxos(bark_BarkRefreshOpts refresh_opts,
-                                   bool no_sync,
-                                   char **status_json_out);
-
-/// Board a specific amount from the onchain wallet into Ark.
-bark_BarkError *bark_board_amount(uint64_t amount_sat, bool no_sync, char **status_json_out);
-
-/// Board all available funds from the onchain wallet into Ark.
-bark_BarkError *bark_board_all(bool no_sync, char **status_json_out);
-
-bark_BarkError *bark_send(const char *destination,
-                          uint64_t amount_sat,
-                          const char *comment,
-                          bool no_sync,
-                          char **status_json_out);
-
-/// Send an onchain payment via an Ark round.
-bark_BarkError *bark_send_round_onchain(const char *destination,
-                                        uint64_t amount_sat,
-                                        bool no_sync,
-                                        char **status_json_out);
-
-/// Offboard specific VTXOs to an optional onchain address.
-bark_BarkError *bark_offboard_specific(const char *const *specific_vtxo_ids,
-                                       uintptr_t num_specific_vtxo_ids,
-                                       const char *optional_address,
+    /// Refresh VTXOs based on specified criteria.
+    bark_BarkError *bark_refresh_vtxos(bark_BarkRefreshOpts refresh_opts,
                                        bool no_sync,
                                        char **status_json_out);
 
-/// Offboard all VTXOs to an optional onchain address.
-bark_BarkError *bark_offboard_all(const char *optional_address,
-                                  bool no_sync,
-                                  char **status_json_out);
+    /// Board a specific amount from the onchain wallet into Ark.
+    bark_BarkError *bark_board_amount(uint64_t amount_sat, bool no_sync, char **status_json_out);
 
-/// Start the exit process for specific VTXOs.
-bark_BarkError *bark_exit_start_specific(const char *const *specific_vtxo_ids,
-                                         uintptr_t num_specific_vtxo_ids,
-                                         char **status_json_out);
+    /// Board all available funds from the onchain wallet into Ark.
+    bark_BarkError *bark_board_all(bool no_sync, char **status_json_out);
 
-/// Start the exit process for all VTXOs in the wallet.
-bark_BarkError *bark_exit_start_all(char **status_json_out);
+    bark_BarkError *bark_send(const char *destination,
+                              uint64_t amount_sat,
+                              const char *comment,
+                              bool no_sync,
+                              char **status_json_out);
 
-/// Progress the exit process once and return the current status.
-bark_BarkError *bark_exit_progress_once(char **status_json_out);
+    /// Send an onchain payment via an Ark round.
+    bark_BarkError *bark_send_round_onchain(const char *destination,
+                                            uint64_t amount_sat,
+                                            bool no_sync,
+                                            char **status_json_out);
 
-/// FFI: Creates a BOLT11 invoice for receiving payments.
-bark_BarkError *bark_bolt11_invoice(uint64_t amount_msat, char **invoice_out);
+    /// Offboard specific VTXOs to an optional onchain address.
+    bark_BarkError *bark_offboard_specific(const char *const *specific_vtxo_ids,
+                                           uintptr_t num_specific_vtxo_ids,
+                                           const char *optional_address,
+                                           bool no_sync,
+                                           char **status_json_out);
 
-/// FFI: Claims a BOLT11 payment using an invoice.
-bark_BarkError *bark_claim_bolt11_payment(const char *bolt11);
+    /// Offboard all VTXOs to an optional onchain address.
+    bark_BarkError *bark_offboard_all(const char *optional_address,
+                                      bool no_sync,
+                                      char **status_json_out);
 
-}  // extern "C"
+    /// Start the exit process for specific VTXOs.
+    bark_BarkError *bark_exit_start_specific(const char *const *specific_vtxo_ids,
+                                             uintptr_t num_specific_vtxo_ids,
+                                             char **status_json_out);
 
-}  // namespace bark
+    /// Start the exit process for all VTXOs in the wallet.
+    bark_BarkError *bark_exit_start_all(char **status_json_out);
 
-#endif  // BARK_CPP_H
+    /// Progress the exit process once and return the current status.
+    bark_BarkError *bark_exit_progress_once(char **status_json_out);
+
+    /// FFI: Creates a BOLT11 invoice for receiving payments.
+    bark_BarkError *bark_bolt11_invoice(uint64_t amount_msat, char **invoice_out);
+
+    /// FFI: Claims a BOLT11 payment using an invoice.
+    bark_BarkError *bark_claim_bolt11_payment(const char *bolt11);
+
+  } // extern "C"
+
+} // namespace bark
+
+#endif // BARK_CPP_H

--- a/bark-cpp/bark-cpp.h
+++ b/bark-cpp/bark-cpp.h
@@ -77,140 +77,94 @@ void bark_free_string(char *s);
 /// Create a new mnemonic
 char *bark_create_mnemonic();
 
-/// Create a new wallet at the specified directory
-bark_BarkError *bark_create_wallet(const char *datadir, bark_BarkCreateOpts opts);
+/// Load an existing wallet or create a new one at the specified directory
+bark_BarkError *bark_load_wallet(const char *datadir, bark_BarkCreateOpts opts);
+
+/// Close the currently loaded wallet
+bark_BarkError *bark_close_wallet();
 
 /// Get offchain and onchain balances
-bark_BarkError *bark_get_balance(const char *datadir,
-                                 bool no_sync,
-                                 const char *mnemonic,
-                                 bark_BarkBalance *balance_out);
+bark_BarkError *bark_get_balance(bool no_sync, bark_BarkBalance *balance_out);
 
 /// Get an onchain address.
-bark_BarkError *bark_get_onchain_address(const char *datadir,
-                                         const char *mnemonic,
-                                         char **address_out);
+bark_BarkError *bark_get_onchain_address(char **address_out);
 
 /// Send funds using the onchain wallet.
-bark_BarkError *bark_send_onchain(const char *datadir,
-                                  const char *mnemonic,
-                                  const char *destination,
+bark_BarkError *bark_send_onchain(const char *destination,
                                   uint64_t amount_sat,
                                   bool no_sync,
                                   char **txid_out);
 
 /// Send all funds from the onchain wallet to a destination address.
-bark_BarkError *bark_drain_onchain(const char *datadir,
-                                   const char *mnemonic,
-                                   const char *destination,
-                                   bool no_sync,
-                                   char **txid_out);
+bark_BarkError *bark_drain_onchain(const char *destination, bool no_sync, char **txid_out);
 
 /// Send funds to multiple recipients using the onchain wallet.
-bark_BarkError *bark_send_many_onchain(const char *datadir,
-                                       const char *mnemonic,
-                                       const char *const *destinations,
+bark_BarkError *bark_send_many_onchain(const char *const *destinations,
                                        const uint64_t *amounts_sat,
                                        uintptr_t num_outputs,
                                        bool no_sync,
                                        char **txid_out);
 
 /// Get the list of onchain UTXOs as a JSON string.
-bark_BarkError *bark_get_onchain_utxos(const char *datadir,
-                                       const char *mnemonic,
-                                       bool no_sync,
-                                       char **utxos_json_out);
+bark_BarkError *bark_get_onchain_utxos(bool no_sync, char **utxos_json_out);
 
 /// Get the wallet's VTXO public key (hex string).
-bark_BarkError *bark_get_vtxo_pubkey(const char *datadir,
-                                     const char *mnemonic,
-                                     char **pubkey_hex_out);
+bark_BarkError *bark_get_vtxo_pubkey(const uint32_t *index, char **pubkey_hex_out);
 
 /// Get the list of VTXOs as a JSON string.
-bark_BarkError *bark_get_vtxos(const char *datadir,
-                               const char *mnemonic,
-                               bool no_sync,
-                               char **vtxos_json_out);
+bark_BarkError *bark_get_vtxos(bool no_sync, char **vtxos_json_out);
 
 /// Refresh VTXOs based on specified criteria.
-bark_BarkError *bark_refresh_vtxos(const char *datadir,
-                                   const char *mnemonic,
-                                   bark_BarkRefreshOpts refresh_opts,
+bark_BarkError *bark_refresh_vtxos(bark_BarkRefreshOpts refresh_opts,
                                    bool no_sync,
                                    char **status_json_out);
 
 /// Board a specific amount from the onchain wallet into Ark.
-bark_BarkError *bark_board_amount(const char *datadir,
-                                  const char *mnemonic,
-                                  uint64_t amount_sat,
-                                  bool no_sync,
-                                  char **status_json_out);
+bark_BarkError *bark_board_amount(uint64_t amount_sat, bool no_sync, char **status_json_out);
 
 /// Board all available funds from the onchain wallet into Ark.
-bark_BarkError *bark_board_all(const char *datadir,
-                               const char *mnemonic,
-                               bool no_sync,
-                               char **status_json_out);
+bark_BarkError *bark_board_all(bool no_sync, char **status_json_out);
 
-bark_BarkError *bark_send(const char *datadir,
-                          const char *mnemonic,
-                          const char *destination,
+bark_BarkError *bark_send(const char *destination,
                           uint64_t amount_sat,
                           const char *comment,
                           bool no_sync,
                           char **status_json_out);
 
 /// Send an onchain payment via an Ark round.
-bark_BarkError *bark_send_round_onchain(const char *datadir,
-                                        const char *mnemonic,
-                                        const char *destination,
+bark_BarkError *bark_send_round_onchain(const char *destination,
                                         uint64_t amount_sat,
                                         bool no_sync,
                                         char **status_json_out);
 
 /// Offboard specific VTXOs to an optional onchain address.
-bark_BarkError *bark_offboard_specific(const char *datadir,
-                                       const char *mnemonic,
-                                       const char *const *specific_vtxo_ids,
+bark_BarkError *bark_offboard_specific(const char *const *specific_vtxo_ids,
                                        uintptr_t num_specific_vtxo_ids,
                                        const char *optional_address,
                                        bool no_sync,
                                        char **status_json_out);
 
 /// Offboard all VTXOs to an optional onchain address.
-bark_BarkError *bark_offboard_all(const char *datadir,
-                                  const char *mnemonic,
-                                  const char *optional_address,
+bark_BarkError *bark_offboard_all(const char *optional_address,
                                   bool no_sync,
                                   char **status_json_out);
 
 /// Start the exit process for specific VTXOs.
-bark_BarkError *bark_exit_start_specific(const char *datadir,
-                                         const char *mnemonic,
-                                         const char *const *specific_vtxo_ids,
+bark_BarkError *bark_exit_start_specific(const char *const *specific_vtxo_ids,
                                          uintptr_t num_specific_vtxo_ids,
                                          char **status_json_out);
 
 /// Start the exit process for all VTXOs in the wallet.
-bark_BarkError *bark_exit_start_all(const char *datadir,
-                                    const char *mnemonic,
-                                    char **status_json_out);
+bark_BarkError *bark_exit_start_all(char **status_json_out);
 
 /// Progress the exit process once and return the current status.
-bark_BarkError *bark_exit_progress_once(const char *datadir,
-                                        const char *mnemonic,
-                                        char **status_json_out);
+bark_BarkError *bark_exit_progress_once(char **status_json_out);
 
 /// FFI: Creates a BOLT11 invoice for receiving payments.
-bark_BarkError *bark_bolt11_invoice(const char *datadir,
-                                    const char *mnemonic,
-                                    uint64_t amount_msat,
-                                    char **invoice_out);
+bark_BarkError *bark_bolt11_invoice(uint64_t amount_msat, char **invoice_out);
 
 /// FFI: Claims a BOLT11 payment using an invoice.
-bark_BarkError *bark_claim_bolt11_payment(const char *datadir,
-                                          const char *mnemonic,
-                                          const char *bolt11);
+bark_BarkError *bark_claim_bolt11_payment(const char *bolt11);
 
 }  // extern "C"
 

--- a/bark-cpp/src/ffi_2.rs
+++ b/bark-cpp/src/ffi_2.rs
@@ -10,14 +10,13 @@ use crate::*;
 /// Get the wallet's VTXO public key (hex string).
 #[no_mangle]
 pub extern "C" fn bark_get_vtxo_pubkey(
-    datadir: *const c_char,
-    mnemonic: *const c_char,
+    index: *const u32,
     pubkey_hex_out: *mut *mut c_char,
 ) -> *mut BarkError {
     debug!("bark_get_vtxo_pubkey called");
 
     // --- Input Validation ---
-    if datadir.is_null() || mnemonic.is_null() || pubkey_hex_out.is_null() {
+    if pubkey_hex_out.is_null() {
         error!("Null pointer passed to bark_get_vtxo_pubkey");
         return Box::into_raw(Box::new(BarkError::new("Null pointer argument provided")));
     }
@@ -25,20 +24,15 @@ pub extern "C" fn bark_get_vtxo_pubkey(
         *pubkey_hex_out = ptr::null_mut();
     } // Initialize output
 
-    // --- Conversions ---
-    let datadir_path = match c_string_to_path(datadir) {
-        Ok(p) => p,
-        Err(e) => return Box::into_raw(Box::new(BarkError::new(&e.to_string()))),
-    };
-    let rust_mnemonic = match c_string_to_mnemonic(mnemonic) {
-        Ok(m) => m,
-        Err(e) => return Box::into_raw(Box::new(BarkError::new(&e.to_string()))),
+    let index_opt = if index.is_null() {
+        None
+    } else {
+        Some(unsafe { *index })
     };
 
     // --- Runtime and Async Execution ---
     // `get_vtxo_pubkey` is async because `open_wallet` is async
-    let result =
-        TOKIO_RUNTIME.block_on(async { get_vtxo_pubkey(&datadir_path, rust_mnemonic, None).await });
+    let result = TOKIO_RUNTIME.block_on(async { get_vtxo_pubkey(index_opt).await });
 
     // --- Result Handling ---
     handle_string_result(result, pubkey_hex_out, "get_vtxo_pubkey")
@@ -47,15 +41,13 @@ pub extern "C" fn bark_get_vtxo_pubkey(
 /// Get the list of VTXOs as a JSON string.
 #[no_mangle]
 pub extern "C" fn bark_get_vtxos(
-    datadir: *const c_char,
-    mnemonic: *const c_char,
     no_sync: bool,
     vtxos_json_out: *mut *mut c_char,
 ) -> *mut BarkError {
     debug!("bark_get_vtxos called: no_sync={}", no_sync);
 
     // --- Input Validation ---
-    if datadir.is_null() || mnemonic.is_null() || vtxos_json_out.is_null() {
+    if vtxos_json_out.is_null() {
         error!("Null pointer passed to bark_get_vtxos");
         return Box::into_raw(Box::new(BarkError::new("Null pointer argument provided")));
     }
@@ -63,19 +55,8 @@ pub extern "C" fn bark_get_vtxos(
         *vtxos_json_out = ptr::null_mut();
     } // Initialize output
 
-    // --- Conversions ---
-    let datadir_path = match c_string_to_path(datadir) {
-        Ok(p) => p,
-        Err(e) => return Box::into_raw(Box::new(BarkError::new(&e.to_string()))),
-    };
-    let rust_mnemonic = match c_string_to_mnemonic(mnemonic) {
-        Ok(m) => m,
-        Err(e) => return Box::into_raw(Box::new(BarkError::new(&e.to_string()))),
-    };
-
     // --- Runtime and Async Execution ---
-    let result =
-        TOKIO_RUNTIME.block_on(async { get_vtxos(&datadir_path, rust_mnemonic, no_sync).await });
+    let result = TOKIO_RUNTIME.block_on(async { get_vtxos(no_sync).await });
 
     // --- Result Handling ---
     handle_string_result(result, vtxos_json_out, "get_vtxos")
@@ -84,8 +65,6 @@ pub extern "C" fn bark_get_vtxos(
 /// Refresh VTXOs based on specified criteria.
 #[no_mangle]
 pub extern "C" fn bark_refresh_vtxos(
-    datadir: *const c_char,
-    mnemonic: *const c_char,
     refresh_opts: BarkRefreshOpts, // Pass struct by value
     no_sync: bool,
     status_json_out: *mut *mut c_char,
@@ -99,7 +78,7 @@ pub extern "C" fn bark_refresh_vtxos(
     ); // Use Debug on enum if derived
 
     // --- Input Validation ---
-    if datadir.is_null() || mnemonic.is_null() || status_json_out.is_null() {
+    if status_json_out.is_null() {
         error!("Null pointer passed to bark_refresh_vtxos");
         return Box::into_raw(Box::new(BarkError::new("Null pointer argument provided")));
     }
@@ -117,14 +96,6 @@ pub extern "C" fn bark_refresh_vtxos(
     } // Initialize output
 
     // --- Conversions ---
-    let datadir_path = match c_string_to_path(datadir) {
-        Ok(p) => p,
-        Err(e) => return Box::into_raw(Box::new(BarkError::new(&e.to_string()))),
-    };
-    let rust_mnemonic = match c_string_to_mnemonic(mnemonic) {
-        Ok(m) => m,
-        Err(e) => return Box::into_raw(Box::new(BarkError::new(&e.to_string()))),
-    };
     let rust_mode = match convert_refresh_opts(&refresh_opts) {
         Ok(mode) => mode,
         Err(e) => {
@@ -137,8 +108,7 @@ pub extern "C" fn bark_refresh_vtxos(
     };
 
     // --- Runtime and Async Execution ---
-    let result = TOKIO_RUNTIME
-        .block_on(async { refresh_vtxos(&datadir_path, rust_mnemonic, rust_mode, no_sync).await });
+    let result = TOKIO_RUNTIME.block_on(async { refresh_vtxos(rust_mode, no_sync).await });
 
     // --- Result Handling ---
     handle_string_result(result, status_json_out, "refresh_vtxos")
@@ -149,8 +119,6 @@ pub extern "C" fn bark_refresh_vtxos(
 /// Board a specific amount from the onchain wallet into Ark.
 #[no_mangle]
 pub extern "C" fn bark_board_amount(
-    datadir: *const c_char,
-    mnemonic: *const c_char,
     amount_sat: u64,
     no_sync: bool,
     status_json_out: *mut *mut c_char,
@@ -161,7 +129,7 @@ pub extern "C" fn bark_board_amount(
     );
 
     // --- Input Validation ---
-    if datadir.is_null() || mnemonic.is_null() || status_json_out.is_null() {
+    if status_json_out.is_null() {
         error!("Null pointer passed to bark_board_amount");
         return Box::into_raw(Box::new(BarkError::new("Null pointer argument provided")));
     }
@@ -174,19 +142,10 @@ pub extern "C" fn bark_board_amount(
     } // Initialize output
 
     // --- Conversions ---
-    let datadir_path = match c_string_to_path(datadir) {
-        Ok(p) => p,
-        Err(e) => return Box::into_raw(Box::new(BarkError::new(&e.to_string()))),
-    };
-    let rust_mnemonic = match c_string_to_mnemonic(mnemonic) {
-        Ok(m) => m,
-        Err(e) => return Box::into_raw(Box::new(BarkError::new(&e.to_string()))),
-    };
     let amount = Amount::from_sat(amount_sat);
 
     // --- Runtime and Async Execution ---
-    let result = TOKIO_RUNTIME
-        .block_on(async { board_amount(&datadir_path, rust_mnemonic, amount, no_sync).await });
+    let result = TOKIO_RUNTIME.block_on(async { board_amount(amount, no_sync).await });
 
     // --- Result Handling ---
     handle_string_result(result, status_json_out, "board_amount")
@@ -195,15 +154,13 @@ pub extern "C" fn bark_board_amount(
 /// Board all available funds from the onchain wallet into Ark.
 #[no_mangle]
 pub extern "C" fn bark_board_all(
-    datadir: *const c_char,
-    mnemonic: *const c_char,
     no_sync: bool,
     status_json_out: *mut *mut c_char,
 ) -> *mut BarkError {
     debug!("bark_board_all called: no_sync={}", no_sync);
 
     // --- Input Validation ---
-    if datadir.is_null() || mnemonic.is_null() || status_json_out.is_null() {
+    if status_json_out.is_null() {
         error!("Null pointer passed to bark_board_all");
         return Box::into_raw(Box::new(BarkError::new("Null pointer argument provided")));
     }
@@ -211,19 +168,8 @@ pub extern "C" fn bark_board_all(
         *status_json_out = ptr::null_mut();
     } // Initialize output
 
-    // --- Conversions ---
-    let datadir_path = match c_string_to_path(datadir) {
-        Ok(p) => p,
-        Err(e) => return Box::into_raw(Box::new(BarkError::new(&e.to_string()))),
-    };
-    let rust_mnemonic = match c_string_to_mnemonic(mnemonic) {
-        Ok(m) => m,
-        Err(e) => return Box::into_raw(Box::new(BarkError::new(&e.to_string()))),
-    };
-
     // --- Runtime and Async Execution ---
-    let result =
-        TOKIO_RUNTIME.block_on(async { board_all(&datadir_path, rust_mnemonic, no_sync).await });
+    let result = TOKIO_RUNTIME.block_on(async { board_all(no_sync).await });
 
     // --- Result Handling ---
     handle_string_result(result, status_json_out, "board_all")
@@ -231,8 +177,6 @@ pub extern "C" fn bark_board_all(
 
 #[no_mangle]
 pub extern "C" fn bark_send(
-    datadir: *const c_char,
-    mnemonic: *const c_char,
     destination: *const c_char,
     amount_sat: u64,        // Use 0 or ULLONG_MAX to indicate 'not provided by user'
     comment: *const c_char, // Nullable
@@ -254,8 +198,7 @@ pub extern "C" fn bark_send(
     );
 
     // --- Input Validation ---
-    if datadir.is_null() || mnemonic.is_null() || destination.is_null() || status_json_out.is_null()
-    {
+    if destination.is_null() || status_json_out.is_null() {
         error!("Null pointer passed to bark_send");
         return Box::into_raw(Box::new(BarkError::new("Null pointer argument provided")));
     }
@@ -264,14 +207,6 @@ pub extern "C" fn bark_send(
     } // Initialize output
 
     // --- Conversions ---
-    let datadir_path = match c_string_to_path(datadir) {
-        Ok(p) => p,
-        Err(e) => return Box::into_raw(Box::new(BarkError::new(&e.to_string()))),
-    };
-    let rust_mnemonic = match c_string_to_mnemonic(mnemonic) {
-        Ok(m) => m,
-        Err(e) => return Box::into_raw(Box::new(BarkError::new(&e.to_string()))),
-    };
     let destination_str = match c_string_to_string(destination) {
         Ok(s) => s,
         Err(e) => {
@@ -290,15 +225,7 @@ pub extern "C" fn bark_send(
 
     // --- Runtime and Async Execution ---
     let result = TOKIO_RUNTIME.block_on(async {
-        send_payment(
-            &datadir_path,
-            rust_mnemonic,
-            &destination_str,
-            rust_amount_opt,
-            rust_comment_opt,
-            no_sync,
-        )
-        .await
+        send_payment(&destination_str, rust_amount_opt, rust_comment_opt, no_sync).await
     });
 
     // --- Result Handling ---
@@ -310,8 +237,6 @@ pub extern "C" fn bark_send(
 /// Send an onchain payment via an Ark round.
 #[no_mangle]
 pub extern "C" fn bark_send_round_onchain(
-    datadir: *const c_char,
-    mnemonic: *const c_char,
     destination: *const c_char,
     amount_sat: u64,
     no_sync: bool,
@@ -323,8 +248,7 @@ pub extern "C" fn bark_send_round_onchain(
     );
 
     // --- Input Validation ---
-    if datadir.is_null() || mnemonic.is_null() || destination.is_null() || status_json_out.is_null()
-    {
+    if destination.is_null() || status_json_out.is_null() {
         error!("Null pointer passed to bark_send_round_onchain");
         return Box::into_raw(Box::new(BarkError::new("Null pointer argument provided")));
     }
@@ -337,14 +261,6 @@ pub extern "C" fn bark_send_round_onchain(
     } // Initialize output
 
     // --- Conversions ---
-    let datadir_path = match c_string_to_path(datadir) {
-        Ok(p) => p,
-        Err(e) => return Box::into_raw(Box::new(BarkError::new(&e.to_string()))),
-    };
-    let rust_mnemonic = match c_string_to_mnemonic(mnemonic) {
-        Ok(m) => m,
-        Err(e) => return Box::into_raw(Box::new(BarkError::new(&e.to_string()))),
-    };
     let destination_str = match c_string_to_string(destination) {
         Ok(s) => s,
         Err(e) => {
@@ -357,16 +273,8 @@ pub extern "C" fn bark_send_round_onchain(
     let amount = Amount::from_sat(amount_sat);
 
     // --- Runtime and Async Execution ---
-    let result = TOKIO_RUNTIME.block_on(async {
-        send_round_onchain(
-            &datadir_path,
-            rust_mnemonic,
-            &destination_str,
-            amount,
-            no_sync,
-        )
-        .await
-    });
+    let result = TOKIO_RUNTIME
+        .block_on(async { send_round_onchain(&destination_str, amount, no_sync).await });
 
     // --- Result Handling ---
     handle_string_result(result, status_json_out, "send_round_onchain")
@@ -377,8 +285,6 @@ pub extern "C" fn bark_send_round_onchain(
 /// Offboard specific VTXOs to an optional onchain address.
 #[no_mangle]
 pub extern "C" fn bark_offboard_specific(
-    datadir: *const c_char,
-    mnemonic: *const c_char,
     specific_vtxo_ids: *const *const c_char,
     num_specific_vtxo_ids: usize,
     optional_address: *const c_char, // Nullable
@@ -391,11 +297,7 @@ pub extern "C" fn bark_offboard_specific(
     );
 
     // --- Input Validation ---
-    if datadir.is_null()
-        || mnemonic.is_null()
-        || specific_vtxo_ids.is_null()
-        || status_json_out.is_null()
-    {
+    if specific_vtxo_ids.is_null() || status_json_out.is_null() {
         error!("Null pointer passed to bark_offboard_specific (excluding optional_address)");
         return Box::into_raw(Box::new(BarkError::new("Null pointer argument provided")));
     }
@@ -408,14 +310,6 @@ pub extern "C" fn bark_offboard_specific(
     } // Initialize output
 
     // --- Conversions ---
-    let datadir_path = match c_string_to_path(datadir) {
-        Ok(p) => p,
-        Err(e) => return Box::into_raw(Box::new(BarkError::new(&e.to_string()))),
-    };
-    let rust_mnemonic = match c_string_to_mnemonic(mnemonic) {
-        Ok(m) => m,
-        Err(e) => return Box::into_raw(Box::new(BarkError::new(&e.to_string()))),
-    };
     let rust_address_opt = c_string_to_option(optional_address);
 
     // Convert VTXO ID strings
@@ -430,16 +324,8 @@ pub extern "C" fn bark_offboard_specific(
     };
 
     // --- Runtime and Async Execution ---
-    let result = TOKIO_RUNTIME.block_on(async {
-        offboard_specific(
-            &datadir_path,
-            rust_mnemonic,
-            rust_vtxo_ids,
-            rust_address_opt,
-            no_sync,
-        )
-        .await
-    });
+    let result = TOKIO_RUNTIME
+        .block_on(async { offboard_specific(rust_vtxo_ids, rust_address_opt, no_sync).await });
 
     // --- Result Handling ---
     handle_string_result(result, status_json_out, "offboard_specific")
@@ -448,8 +334,6 @@ pub extern "C" fn bark_offboard_specific(
 /// Offboard all VTXOs to an optional onchain address.
 #[no_mangle]
 pub extern "C" fn bark_offboard_all(
-    datadir: *const c_char,
-    mnemonic: *const c_char,
     optional_address: *const c_char, // Nullable
     no_sync: bool,
     status_json_out: *mut *mut c_char,
@@ -457,7 +341,7 @@ pub extern "C" fn bark_offboard_all(
     debug!("bark_offboard_all called: no_sync={}", no_sync);
 
     // --- Input Validation ---
-    if datadir.is_null() || mnemonic.is_null() || status_json_out.is_null() {
+    if status_json_out.is_null() {
         error!("Null pointer passed to bark_offboard_all (excluding optional_address)");
         return Box::into_raw(Box::new(BarkError::new("Null pointer argument provided")));
     }
@@ -466,20 +350,10 @@ pub extern "C" fn bark_offboard_all(
     } // Initialize output
 
     // --- Conversions ---
-    let datadir_path = match c_string_to_path(datadir) {
-        Ok(p) => p,
-        Err(e) => return Box::into_raw(Box::new(BarkError::new(&e.to_string()))),
-    };
-    let rust_mnemonic = match c_string_to_mnemonic(mnemonic) {
-        Ok(m) => m,
-        Err(e) => return Box::into_raw(Box::new(BarkError::new(&e.to_string()))),
-    };
     let rust_address_opt = c_string_to_option(optional_address);
 
     // --- Runtime and Async Execution ---
-    let result = TOKIO_RUNTIME.block_on(async {
-        offboard_all(&datadir_path, rust_mnemonic, rust_address_opt, no_sync).await
-    });
+    let result = TOKIO_RUNTIME.block_on(async { offboard_all(rust_address_opt, no_sync).await });
 
     // --- Result Handling ---
     handle_string_result(result, status_json_out, "offboard_all")
@@ -490,8 +364,6 @@ pub extern "C" fn bark_offboard_all(
 /// Start the exit process for specific VTXOs.
 #[no_mangle]
 pub extern "C" fn bark_exit_start_specific(
-    datadir: *const c_char,
-    mnemonic: *const c_char,
     specific_vtxo_ids: *const *const c_char,
     num_specific_vtxo_ids: usize,
     status_json_out: *mut *mut c_char,
@@ -502,11 +374,7 @@ pub extern "C" fn bark_exit_start_specific(
     );
 
     // --- Input Validation ---
-    if datadir.is_null()
-        || mnemonic.is_null()
-        || specific_vtxo_ids.is_null()
-        || status_json_out.is_null()
-    {
+    if specific_vtxo_ids.is_null() || status_json_out.is_null() {
         error!("Null pointer passed to bark_exit_start_specific");
         return Box::into_raw(Box::new(BarkError::new("Null pointer argument provided")));
     }
@@ -519,14 +387,6 @@ pub extern "C" fn bark_exit_start_specific(
     } // Initialize output
 
     // --- Conversions ---
-    let datadir_path = match c_string_to_path(datadir) {
-        Ok(p) => p,
-        Err(e) => return Box::into_raw(Box::new(BarkError::new(&e.to_string()))),
-    };
-    let rust_mnemonic = match c_string_to_mnemonic(mnemonic) {
-        Ok(m) => m,
-        Err(e) => return Box::into_raw(Box::new(BarkError::new(&e.to_string()))),
-    };
     // Convert VTXO ID strings
     let rust_vtxo_ids = match convert_vtxo_ids(specific_vtxo_ids, num_specific_vtxo_ids) {
         Ok(ids) => ids,
@@ -539,9 +399,7 @@ pub extern "C" fn bark_exit_start_specific(
     };
 
     // --- Runtime and Async Execution ---
-    let result = TOKIO_RUNTIME.block_on(async {
-        start_exit_for_vtxos(&datadir_path, rust_mnemonic, rust_vtxo_ids).await
-    });
+    let result = TOKIO_RUNTIME.block_on(async { start_exit_for_vtxos(rust_vtxo_ids).await });
 
     // --- Result Handling ---
     handle_string_result(result, status_json_out, "exit_start_specific")
@@ -549,15 +407,11 @@ pub extern "C" fn bark_exit_start_specific(
 
 /// Start the exit process for all VTXOs in the wallet.
 #[no_mangle]
-pub extern "C" fn bark_exit_start_all(
-    datadir: *const c_char,
-    mnemonic: *const c_char,
-    status_json_out: *mut *mut c_char,
-) -> *mut BarkError {
+pub extern "C" fn bark_exit_start_all(status_json_out: *mut *mut c_char) -> *mut BarkError {
     debug!("bark_exit_start_all called");
 
     // --- Input Validation ---
-    if datadir.is_null() || mnemonic.is_null() || status_json_out.is_null() {
+    if status_json_out.is_null() {
         error!("Null pointer passed to bark_exit_start_all");
         return Box::into_raw(Box::new(BarkError::new("Null pointer argument provided")));
     }
@@ -565,19 +419,8 @@ pub extern "C" fn bark_exit_start_all(
         *status_json_out = ptr::null_mut();
     } // Initialize output
 
-    // --- Conversions ---
-    let datadir_path = match c_string_to_path(datadir) {
-        Ok(p) => p,
-        Err(e) => return Box::into_raw(Box::new(BarkError::new(&e.to_string()))),
-    };
-    let rust_mnemonic = match c_string_to_mnemonic(mnemonic) {
-        Ok(m) => m,
-        Err(e) => return Box::into_raw(Box::new(BarkError::new(&e.to_string()))),
-    };
-
     // --- Runtime and Async Execution ---
-    let result = TOKIO_RUNTIME
-        .block_on(async { start_exit_for_entire_wallet(&datadir_path, rust_mnemonic).await });
+    let result = TOKIO_RUNTIME.block_on(async { start_exit_for_entire_wallet().await });
 
     // --- Result Handling ---
     handle_string_result(result, status_json_out, "exit_start_all")
@@ -585,15 +428,11 @@ pub extern "C" fn bark_exit_start_all(
 
 /// Progress the exit process once and return the current status.
 #[no_mangle]
-pub extern "C" fn bark_exit_progress_once(
-    datadir: *const c_char,
-    mnemonic: *const c_char,
-    status_json_out: *mut *mut c_char,
-) -> *mut BarkError {
+pub extern "C" fn bark_exit_progress_once(status_json_out: *mut *mut c_char) -> *mut BarkError {
     debug!("bark_exit_progress_once called");
 
     // --- Input Validation ---
-    if datadir.is_null() || mnemonic.is_null() || status_json_out.is_null() {
+    if status_json_out.is_null() {
         error!("Null pointer passed to bark_exit_progress_once");
         return Box::into_raw(Box::new(BarkError::new("Null pointer argument provided")));
     }
@@ -601,19 +440,8 @@ pub extern "C" fn bark_exit_progress_once(
         *status_json_out = ptr::null_mut();
     } // Initialize output
 
-    // --- Conversions ---
-    let datadir_path = match c_string_to_path(datadir) {
-        Ok(p) => p,
-        Err(e) => return Box::into_raw(Box::new(BarkError::new(&e.to_string()))),
-    };
-    let rust_mnemonic = match c_string_to_mnemonic(mnemonic) {
-        Ok(m) => m,
-        Err(e) => return Box::into_raw(Box::new(BarkError::new(&e.to_string()))),
-    };
-
     // --- Runtime and Async Execution ---
-    let result =
-        TOKIO_RUNTIME.block_on(async { exit_progress_once(&datadir_path, rust_mnemonic).await });
+    let result = TOKIO_RUNTIME.block_on(async { exit_progress_once().await });
 
     // --- Result Handling ---
     handle_string_result(result, status_json_out, "exit_progress_once")
@@ -622,67 +450,44 @@ pub extern "C" fn bark_exit_progress_once(
 /// FFI: Creates a BOLT11 invoice for receiving payments.
 #[no_mangle]
 pub extern "C" fn bark_bolt11_invoice(
-    datadir: *const c_char,
-    mnemonic: *const c_char,
     amount_msat: u64,
     invoice_out: *mut *mut c_char,
 ) -> *mut BarkError {
-    if datadir.is_null() || mnemonic.is_null() || invoice_out.is_null() {
+    if invoice_out.is_null() {
         return Box::into_raw(Box::new(BarkError::new("Null pointer argument provided")));
     }
     unsafe {
         *invoice_out = ptr::null_mut();
     }
 
-    let datadir_path = match c_string_to_path(datadir) {
-        Ok(p) => p,
-        Err(e) => return Box::into_raw(Box::new(BarkError::new(&e.to_string()))),
-    };
-    let rust_mnemonic = match c_string_to_mnemonic(mnemonic) {
-        Ok(m) => m,
-        Err(e) => return Box::into_raw(Box::new(BarkError::new(&e.to_string()))),
-    };
-
-    let result = TOKIO_RUNTIME
-        .block_on(async { bolt11_invoice(&datadir_path, rust_mnemonic, amount_msat).await });
+    let result = TOKIO_RUNTIME.block_on(async { bolt11_invoice(amount_msat).await });
 
     handle_string_result(result, invoice_out, "bolt11_invoice")
 }
 
 /// FFI: Claims a BOLT11 payment using an invoice.
 #[no_mangle]
-pub extern "C" fn bark_claim_bolt11_payment(
-    datadir: *const c_char,
-    mnemonic: *const c_char,
-    bolt11: *const c_char,
-) -> *mut BarkError {
-    if datadir.is_null() || mnemonic.is_null() || bolt11.is_null() {
+pub extern "C" fn bark_claim_bolt11_payment(bolt11: *const c_char) -> *mut BarkError {
+    debug!("bark_claim_bolt11_payment called");
+
+    // --- Input Validation ---
+    if bolt11.is_null() {
+        error!("Null pointer passed to bark_claim_bolt11_payment");
         return Box::into_raw(Box::new(BarkError::new("Null pointer argument provided")));
     }
-    let datadir_path = match c_string_to_path(datadir) {
-        Ok(p) => p,
-        Err(e) => return Box::into_raw(Box::new(BarkError::new(&e.to_string()))),
-    };
-    let rust_mnemonic = match c_string_to_mnemonic(mnemonic) {
-        Ok(m) => m,
-        Err(e) => return Box::into_raw(Box::new(BarkError::new(&e.to_string()))),
-    };
+
+    // --- Conversions ---
     let rust_bolt11 = match c_string_to_string(bolt11) {
         Ok(s) => s,
         Err(e) => return Box::into_raw(Box::new(BarkError::new(&e.to_string()))),
     };
 
-    let result = TOKIO_RUNTIME
-        .block_on(async { claim_bolt11_payment(&datadir_path, rust_mnemonic, rust_bolt11).await });
+    // --- Runtime and Async Execution ---
+    let result = TOKIO_RUNTIME.block_on(async { claim_bolt11_payment(rust_bolt11).await });
 
+    // --- Result Handling ---
     match result {
-        Ok(_) => {
-            debug!("Claimed bolt11 payment successfully");
-            ptr::null_mut()
-        }
-        Err(e) => {
-            error!("Failed to claim bolt11 payment: {}", e);
-            Box::into_raw(Box::new(BarkError::new(&e.to_string())))
-        }
+        Ok(_) => ptr::null_mut(),
+        Err(e) => Box::into_raw(Box::new(BarkError::new(&e.to_string()))),
     }
 }

--- a/bark-cpp/src/ffi_utils.rs
+++ b/bark-cpp/src/ffi_utils.rs
@@ -1,6 +1,5 @@
 use std::{
     ffi::{c_char, CStr, CString},
-    path::PathBuf,
     ptr, slice,
     str::FromStr,
 };
@@ -245,34 +244,6 @@ pub(crate) fn handle_string_result(
             ))))
         }
     }
-}
-
-// Helper to convert C string to PathBuf
-pub fn c_string_to_path(s: *const c_char) -> anyhow::Result<PathBuf> {
-    if s.is_null() {
-        bail!("C path string pointer is null");
-    }
-    let path_str = unsafe { CStr::from_ptr(s) }
-        .to_str()
-        .context("Failed to convert C path string to UTF-8")?;
-    if path_str.is_empty() {
-        bail!("Path string is empty");
-    }
-    Ok(PathBuf::from(path_str))
-}
-
-// Helper to convert C string to Mnemonic
-pub(crate) fn c_string_to_mnemonic(s: *const c_char) -> anyhow::Result<Mnemonic> {
-    if s.is_null() {
-        bail!("C mnemonic string pointer is null");
-    }
-    let mnemonic_str = unsafe { CStr::from_ptr(s) }
-        .to_str()
-        .context("Failed to convert C mnemonic string to UTF-8")?;
-    if mnemonic_str.is_empty() {
-        bail!("Mnemonic string is empty");
-    }
-    Mnemonic::from_str(mnemonic_str).context("Invalid mnemonic format")
 }
 
 // Extract string from C string

--- a/bark-cpp/src/main.rs
+++ b/bark-cpp/src/main.rs
@@ -1,5 +1,5 @@
 use anyhow;
-use bark_cpp::{create_wallet, get_ark_info, get_balance, init_logger, ConfigOpts, CreateOpts};
+use bark_cpp::{get_ark_info, get_balance, init_logger, load_wallet, ConfigOpts, CreateOpts};
 use bip39::Mnemonic;
 
 use logger::log::{debug, error, info};
@@ -67,18 +67,18 @@ async fn main() -> anyhow::Result<()> {
     );
 
     debug!("Attempting to create wallet...");
-    if let Err(e) = create_wallet(&datadir, opts).await {
-        error!("Failed to create wallet: {}", e);
-        return Err(anyhow::anyhow!("Wallet creation failed: {}", e));
+    if let Err(e) = load_wallet(&datadir, opts).await {
+        error!("Failed to load wallet: {}", e);
+        return Err(anyhow::anyhow!("Wallet loading failed: {}", e));
     }
 
-    info!("Wallet created successfully at {}", datadir.display());
+    info!("Wallet loaded successfully from {}", datadir.display());
 
     debug!("Retrieving wallet balance...");
-    let balance = get_balance(&datadir, true, mnemonic.clone()).await?;
+    let balance = get_balance(true).await?;
     info!("Wallet balance is {}", balance.offchain);
 
-    let info = get_ark_info(&datadir, mnemonic).await?;
+    let info = get_ark_info().await?;
     info!("Wallet info is {:?}", info);
 
     debug!("Application completed successfully");

--- a/react-native-nitro-ark/cpp/bark-cpp.h
+++ b/react-native-nitro-ark/cpp/bark-cpp.h
@@ -80,324 +80,99 @@ namespace bark
     const char *bark_error_message(const bark_BarkError *error);
 
     /// Frees a C string allocated by a bark-cpp function.
-    ///
-    /// This function should be called by the C/C++ side on any `char*`
-    /// that was returned by functions like `bark_create_mnemonic`,
-    /// `bark_get_onchain_address`, `bark_send_onchain`, etc.
-    ///
-    /// # Safety
-    ///
-    /// The pointer `s` must have been previously allocated by Rust using
-    /// `CString::into_raw` or a similar mechanism within this library.
-    /// Calling this with a null pointer is safe (it does nothing).
-    /// Calling this with a pointer not allocated by this library, or calling
-    /// it more than once on the same pointer, results in undefined behavior.
     void bark_free_string(char *s);
 
     /// Create a new mnemonic
-    ///
-    /// @return The mnemonic string as a C string, or NULL on error
     char *bark_create_mnemonic();
 
-    /// Create a new wallet at the specified directory
-    ///
-    /// @param datadir Path to the data directory
-    /// @param opts Creation options
-    /// @return Error pointer or NULL on success
-    bark_BarkError *bark_create_wallet(const char *datadir, bark_BarkCreateOpts opts);
+    /// Load an existing wallet or create a new one at the specified directory
+    bark_BarkError *bark_load_wallet(const char *datadir, bark_BarkCreateOpts opts);
+
+    /// Close the currently loaded wallet
+    bark_BarkError *bark_close_wallet();
 
     /// Get offchain and onchain balances
-    ///
-    /// @param datadir Path to the data directory
-    /// @param no_sync Whether to skip syncing the wallet
-    /// @param balance_out Pointer to a BarkBalance struct where the result will be stored
-    /// @return Error pointer or NULL on success
-    bark_BarkError *bark_get_balance(const char *datadir,
-                                     bool no_sync,
-                                     const char *mnemonic,
-                                     bark_BarkBalance *balance_out);
+    bark_BarkError *bark_get_balance(bool no_sync, bark_BarkBalance *balance_out);
 
     /// Get an onchain address.
-    ///
-    /// The returned address string must be freed by the caller using `bark_free_string`.
-    ///
-    /// @param datadir Path to the data directory
-    /// @param mnemonic The wallet mnemonic phrase
-    /// @param address_out Pointer to a `*mut c_char` where the address string pointer will be written.
-    /// @return Error pointer or NULL on success.
-    bark_BarkError *bark_get_onchain_address(const char *datadir,
-                                             const char *mnemonic,
-                                             char **address_out);
+    bark_BarkError *bark_get_onchain_address(char **address_out);
 
     /// Send funds using the onchain wallet.
-    ///
-    /// The returned transaction ID string must be freed by the caller using `bark_free_string`.
-    ///
-    /// @param datadir Path to the data directory
-    /// @param mnemonic The wallet mnemonic phrase
-    /// @param destination The destination Bitcoin address as a string
-    /// @param amount_sat The amount to send in satoshis
-    /// @param no_sync Whether to skip syncing the wallet before sending
-    /// @param txid_out Pointer to a `*mut c_char` where the transaction ID string pointer will be written.
-    /// @return Error pointer or NULL on success.
-    bark_BarkError *bark_send_onchain(const char *datadir,
-                                      const char *mnemonic,
-                                      const char *destination,
+    bark_BarkError *bark_send_onchain(const char *destination,
                                       uint64_t amount_sat,
                                       bool no_sync,
                                       char **txid_out);
 
     /// Send all funds from the onchain wallet to a destination address.
-    ///
-    /// The returned transaction ID string must be freed by the caller using `bark_free_string`.
-    ///
-    /// @param datadir Path to the data directory
-    /// @param mnemonic The wallet mnemonic phrase
-    /// @param destination The destination Bitcoin address as a string
-    /// @param no_sync Whether to skip syncing the wallet before sending
-    /// @param txid_out Pointer to a `*mut c_char` where the transaction ID string pointer will be written.
-    /// @return Error pointer or NULL on success.
-    bark_BarkError *bark_drain_onchain(const char *datadir,
-                                       const char *mnemonic,
-                                       const char *destination,
-                                       bool no_sync,
-                                       char **txid_out);
+    bark_BarkError *bark_drain_onchain(const char *destination, bool no_sync, char **txid_out);
 
     /// Send funds to multiple recipients using the onchain wallet.
-    ///
-    /// The returned transaction ID string must be freed by the caller using `bark_free_string`.
-    ///
-    /// @param datadir Path to the data directory
-    /// @param mnemonic The wallet mnemonic phrase
-    /// @param destinations Array of C strings representing destination Bitcoin addresses
-    /// @param amounts_sat Array of u64 representing amounts in satoshis (must match destinations array length)
-    /// @param num_outputs The number of outputs (length of the destinations and amounts_sat arrays)
-    /// @param no_sync Whether to skip syncing the wallet before sending
-    /// @param txid_out Pointer to a `*mut c_char` where the transaction ID string pointer will be written.
-    /// @return Error pointer or NULL on success.
-    bark_BarkError *bark_send_many_onchain(const char *datadir,
-                                           const char *mnemonic,
-                                           const char *const *destinations,
+    bark_BarkError *bark_send_many_onchain(const char *const *destinations,
                                            const uint64_t *amounts_sat,
                                            uintptr_t num_outputs,
                                            bool no_sync,
                                            char **txid_out);
 
     /// Get the list of onchain UTXOs as a JSON string.
-    ///
-    /// The returned JSON string must be freed by the caller using `bark_free_string`.
-    ///
-    /// @param datadir Path to the data directory
-    /// @param mnemonic The wallet mnemonic phrase
-    /// @param no_sync Whether to skip syncing the wallet before fetching
-    /// @param utxos_json_out Pointer to a `*mut c_char` where the JSON string pointer will be written.
-    /// @return Error pointer or NULL on success.
-    bark_BarkError *bark_get_onchain_utxos(const char *datadir,
-                                           const char *mnemonic,
-                                           bool no_sync,
-                                           char **utxos_json_out);
+    bark_BarkError *bark_get_onchain_utxos(bool no_sync, char **utxos_json_out);
 
     /// Get the wallet's VTXO public key (hex string).
-    ///
-    /// The returned public key string must be freed by the caller using `bark_free_string`.
-    ///
-    /// @param datadir Path to the data directory
-    /// @param mnemonic The wallet mnemonic phrase
-    /// @param pubkey_hex_out Pointer to a `*mut c_char` where the hex string pointer will be written.
-    /// @return Error pointer or NULL on success.
-    bark_BarkError *bark_get_vtxo_pubkey(const char *datadir,
-                                         const char *mnemonic,
-                                         char **pubkey_hex_out);
+    bark_BarkError *bark_get_vtxo_pubkey(const uint32_t *index, char **pubkey_hex_out);
 
     /// Get the list of VTXOs as a JSON string.
-    ///
-    /// The returned JSON string must be freed by the caller using `bark_free_string`.
-    ///
-    /// @param datadir Path to the data directory
-    /// @param mnemonic The wallet mnemonic phrase
-    /// @param no_sync Whether to skip syncing the wallet before fetching
-    /// @param vtxos_json_out Pointer to a `*mut c_char` where the JSON string pointer will be written.
-    /// @return Error pointer or NULL on success.
-    bark_BarkError *bark_get_vtxos(const char *datadir,
-                                   const char *mnemonic,
-                                   bool no_sync,
-                                   char **vtxos_json_out);
+    bark_BarkError *bark_get_vtxos(bool no_sync, char **vtxos_json_out);
 
     /// Refresh VTXOs based on specified criteria.
-    ///
-    /// The returned JSON status string must be freed by the caller using `bark_free_string`.
-    ///
-    /// @param datadir Path to the data directory
-    /// @param mnemonic The wallet mnemonic phrase
-    /// @param refresh_opts Options specifying which VTXOs to refresh
-    /// @param no_sync Whether to skip syncing the wallet before refreshing
-    /// @param status_json_out Pointer to a `*mut c_char` where the JSON status string will be written.
-    /// @return Error pointer or NULL on success.
-    bark_BarkError *bark_refresh_vtxos(const char *datadir,
-                                       const char *mnemonic,
-                                       bark_BarkRefreshOpts refresh_opts,
+    bark_BarkError *bark_refresh_vtxos(bark_BarkRefreshOpts refresh_opts,
                                        bool no_sync,
                                        char **status_json_out);
 
     /// Board a specific amount from the onchain wallet into Ark.
-    ///
-    /// The returned JSON status string must be freed by the caller using `bark_free_string`.
-    ///
-    /// @param datadir Path to the data directory
-    /// @param mnemonic The wallet mnemonic phrase
-    /// @param amount_sat The amount in satoshis to board
-    /// @param no_sync Whether to skip syncing the onchain wallet before boarding
-    /// @param status_json_out Pointer to a `*mut c_char` where the JSON status string will be written.
-    /// @return Error pointer or NULL on success.
-    bark_BarkError *bark_board_amount(const char *datadir,
-                                      const char *mnemonic,
-                                      uint64_t amount_sat,
-                                      bool no_sync,
-                                      char **status_json_out);
+    bark_BarkError *bark_board_amount(uint64_t amount_sat, bool no_sync, char **status_json_out);
 
     /// Board all available funds from the onchain wallet into Ark.
-    ///
-    /// The returned JSON status string must be freed by the caller using `bark_free_string`.
-    ///
-    /// @param datadir Path to the data directory
-    /// @param mnemonic The wallet mnemonic phrase
-    /// @param no_sync Whether to skip syncing the onchain wallet before boarding
-    /// @param status_json_out Pointer to a `*mut c_char` where the JSON status string will be written.
-    /// @return Error pointer or NULL on success.
-    bark_BarkError *bark_board_all(const char *datadir,
-                                   const char *mnemonic,
-                                   bool no_sync,
-                                   char **status_json_out);
+    bark_BarkError *bark_board_all(bool no_sync, char **status_json_out);
 
-    bark_BarkError *bark_send(const char *datadir,
-                              const char *mnemonic,
-                              const char *destination,
+    bark_BarkError *bark_send(const char *destination,
                               uint64_t amount_sat,
                               const char *comment,
                               bool no_sync,
                               char **status_json_out);
 
     /// Send an onchain payment via an Ark round.
-    ///
-    /// The returned JSON status string must be freed by the caller using `bark_free_string`.
-    ///
-    /// @param datadir Path to the data directory
-    /// @param mnemonic The wallet mnemonic phrase
-    /// @param destination The destination Bitcoin address as a string
-    /// @param amount_sat The amount in satoshis to send
-    /// @param no_sync Whether to skip syncing the wallet before sending
-    /// @param status_json_out Pointer to a `*mut c_char` where the JSON status string will be written.
-    /// @return Error pointer or NULL on success.
-    bark_BarkError *bark_send_round_onchain(const char *datadir,
-                                            const char *mnemonic,
-                                            const char *destination,
+    bark_BarkError *bark_send_round_onchain(const char *destination,
                                             uint64_t amount_sat,
                                             bool no_sync,
                                             char **status_json_out);
 
     /// Offboard specific VTXOs to an optional onchain address.
-    ///
-    /// The returned JSON result string must be freed by the caller using `bark_free_string`.
-    ///
-    /// @param datadir Path to the data directory
-    /// @param mnemonic The wallet mnemonic phrase
-    /// @param specific_vtxo_ids Array of VtxoId strings (cannot be empty)
-    /// @param num_specific_vtxo_ids Number of VtxoIds in the array
-    /// @param optional_address Optional destination Bitcoin address (pass NULL if not provided)
-    /// @param no_sync Whether to skip syncing the wallet
-    /// @param status_json_out Pointer to a `*mut c_char` where the JSON result string will be written.
-    /// @return Error pointer or NULL on success.
-    bark_BarkError *bark_offboard_specific(const char *datadir,
-                                           const char *mnemonic,
-                                           const char *const *specific_vtxo_ids,
+    bark_BarkError *bark_offboard_specific(const char *const *specific_vtxo_ids,
                                            uintptr_t num_specific_vtxo_ids,
                                            const char *optional_address,
                                            bool no_sync,
                                            char **status_json_out);
 
     /// Offboard all VTXOs to an optional onchain address.
-    ///
-    /// The returned JSON result string must be freed by the caller using `bark_free_string`.
-    ///
-    /// @param datadir Path to the data directory
-    /// @param mnemonic The wallet mnemonic phrase
-    /// @param optional_address Optional destination Bitcoin address (pass NULL if not provided)
-    /// @param no_sync Whether to skip syncing the wallet
-    /// @param status_json_out Pointer to a `*mut c_char` where the JSON result string will be written.
-    /// @return Error pointer or NULL on success.
-    bark_BarkError *bark_offboard_all(const char *datadir,
-                                      const char *mnemonic,
-                                      const char *optional_address,
+    bark_BarkError *bark_offboard_all(const char *optional_address,
                                       bool no_sync,
                                       char **status_json_out);
 
     /// Start the exit process for specific VTXOs.
-    ///
-    /// The returned JSON success string must be freed by the caller using `bark_free_string`.
-    ///
-    /// @param datadir Path to the data directory
-    /// @param mnemonic The wallet mnemonic phrase
-    /// @param specific_vtxo_ids Array of VtxoId strings (cannot be empty)
-    /// @param num_specific_vtxo_ids Number of VtxoIds in the array
-    /// @param status_json_out Pointer to a `*mut c_char` where the JSON success string will be written.
-    /// @return Error pointer or NULL on success.
-    bark_BarkError *bark_exit_start_specific(const char *datadir,
-                                             const char *mnemonic,
-                                             const char *const *specific_vtxo_ids,
+    bark_BarkError *bark_exit_start_specific(const char *const *specific_vtxo_ids,
                                              uintptr_t num_specific_vtxo_ids,
                                              char **status_json_out);
 
     /// Start the exit process for all VTXOs in the wallet.
-    ///
-    /// The returned JSON success string must be freed by the caller using `bark_free_string`.
-    ///
-    /// @param datadir Path to the data directory
-    /// @param mnemonic The wallet mnemonic phrase
-    /// @param status_json_out Pointer to a `*mut c_char` where the JSON success string will be written.
-    /// @return Error pointer or NULL on success.
-    bark_BarkError *bark_exit_start_all(const char *datadir,
-                                        const char *mnemonic,
-                                        char **status_json_out);
+    bark_BarkError *bark_exit_start_all(char **status_json_out);
 
     /// Progress the exit process once and return the current status.
-    ///
-    /// The returned JSON status string must be freed by the caller using `bark_free_string`.
-    ///
-    /// @param datadir Path to the data directory
-    /// @param mnemonic The wallet mnemonic phrase
-    /// @param status_json_out Pointer to a `*mut c_char` where the JSON status string will be written.
-    /// @return Error pointer or NULL on success.
-    bark_BarkError *bark_exit_progress_once(const char *datadir,
-                                            const char *mnemonic,
-                                            char **status_json_out);
+    bark_BarkError *bark_exit_progress_once(char **status_json_out);
 
     /// FFI: Creates a BOLT11 invoice for receiving payments.
-    ///
-    /// # Arguments
-    /// * `datadir` - The directory where the wallet data is stored.
-    /// * `mnemonic` - The wallet's mnemonic phrase.
-    /// * `amount_msat` - The amount for the invoice in millisatoshis.
-    /// * `invoice_out` - A pointer to a C string that will be populated with the BOLT11 invoice.
-    ///
-    /// # Returns
-    /// A null pointer on success, or a pointer to a `BarkError` on failure.
-    bark_BarkError *bark_bolt11_invoice(const char *datadir,
-                                        const char *mnemonic,
-                                        uint64_t amount_msat,
-                                        char **invoice_out);
+    bark_BarkError *bark_bolt11_invoice(uint64_t amount_msat, char **invoice_out);
 
     /// FFI: Claims a BOLT11 payment using an invoice.
-    ///
-    /// # Arguments
-    /// * `datadir` - The directory where the wallet data is stored.
-    /// * `mnemonic` - The wallet's mnemonic phrase.
-    /// * `bolt11` - The BOLT11 invoice to be paid/claimed.
-    ///
-    /// # Returns
-    /// A null pointer on success, or a pointer to a `BarkError` on failure.
-    bark_BarkError *bark_claim_bolt11_payment(const char *datadir,
-                                              const char *mnemonic,
-                                              const char *bolt11);
+    bark_BarkError *bark_claim_bolt11_payment(const char *bolt11);
 
   } // extern "C"
 

--- a/react-native-nitro-ark/example/src/App.tsx
+++ b/react-native-nitro-ark/example/src/App.tsx
@@ -195,8 +195,8 @@ export default function ArkApp() {
       },
     };
     runOperation(
-      'createWallet',
-      () => NitroArk.createWallet(ARK_DATA_PATH, opts),
+      'loadWallet',
+      () => NitroArk.loadWallet(ARK_DATA_PATH, opts),
       () => {
         setResults('Wallet created successfully!');
       }
@@ -211,7 +211,7 @@ export default function ArkApp() {
     const opName = `getBalance (noSync: ${noSync})`;
     runOperation(
       opName,
-      () => NitroArk.getBalance(ARK_DATA_PATH, mnemonic, noSync),
+      () => NitroArk.getBalance(noSync),
       (balance: BarkBalance) => {
         setBalanceState({
           onchain: balance.onchain,
@@ -229,9 +229,7 @@ export default function ArkApp() {
       setError('Mnemonic required');
       return;
     }
-    runOperation('getOnchainAddress', () =>
-      NitroArk.getOnchainAddress(ARK_DATA_PATH, mnemonic)
-    );
+    runOperation('getOnchainAddress', () => NitroArk.getOnchainAddress());
   };
 
   const handleGetOnchainUtxos = (noSync: boolean) => {
@@ -240,7 +238,7 @@ export default function ArkApp() {
       return;
     }
     runOperation(`getOnchainUtxos (noSync: ${noSync})`, () =>
-      NitroArk.getOnchainUtxos(ARK_DATA_PATH, mnemonic, noSync)
+      NitroArk.getOnchainUtxos(noSync)
     );
   };
 
@@ -249,9 +247,7 @@ export default function ArkApp() {
       setError('Mnemonic required');
       return;
     }
-    runOperation('getVtxoPubkey', () =>
-      NitroArk.getVtxoPubkey(ARK_DATA_PATH, mnemonic)
-    );
+    runOperation('getVtxoPubkey', () => NitroArk.getVtxoPubkey());
   };
 
   const handleGetVtxos = (noSync: boolean) => {
@@ -260,7 +256,7 @@ export default function ArkApp() {
       return;
     }
     runOperation(`getVtxos (noSync: ${noSync})`, () =>
-      NitroArk.getVtxos(ARK_DATA_PATH, mnemonic, noSync)
+      NitroArk.getVtxos(noSync)
     );
   };
 
@@ -275,13 +271,7 @@ export default function ArkApp() {
       return;
     }
     runOperation(`sendOnchain (noSync: ${noSync})`, () =>
-      NitroArk.sendOnchain(
-        ARK_DATA_PATH,
-        mnemonic,
-        destinationAddress,
-        amountNum,
-        noSync
-      )
+      NitroArk.sendOnchain(destinationAddress, amountNum, noSync)
     );
   };
 
@@ -291,7 +281,7 @@ export default function ArkApp() {
       return;
     }
     runOperation(`drainOnchain (noSync: ${noSync})`, () =>
-      NitroArk.drainOnchain(ARK_DATA_PATH, mnemonic, destinationAddress, noSync)
+      NitroArk.drainOnchain(destinationAddress, noSync)
     );
   };
 
@@ -313,7 +303,7 @@ export default function ArkApp() {
       // Add more outputs here if needed, maybe from a more complex input UI
     ];
     runOperation(`sendManyOnchain (noSync: ${noSync})`, () =>
-      NitroArk.sendManyOnchain(ARK_DATA_PATH, mnemonic, outputs, noSync)
+      NitroArk.sendManyOnchain(outputs, noSync)
     );
   };
 
@@ -340,7 +330,7 @@ export default function ArkApp() {
     }
 
     runOperation(`refreshVtxos (mode: ${mode}, noSync: ${noSync})`, () =>
-      NitroArk.refreshVtxos(ARK_DATA_PATH, mnemonic, refreshOpts, noSync)
+      NitroArk.refreshVtxos(refreshOpts, noSync)
     );
   };
 
@@ -355,7 +345,7 @@ export default function ArkApp() {
       return;
     }
     runOperation(`boardAmount (noSync: ${noSync})`, () =>
-      NitroArk.boardAmount(ARK_DATA_PATH, mnemonic, amountNum, noSync)
+      NitroArk.boardAmount(amountNum, noSync)
     );
   };
 
@@ -365,7 +355,7 @@ export default function ArkApp() {
       return;
     }
     runOperation(`boardAll (noSync: ${noSync})`, () =>
-      NitroArk.boardAll(ARK_DATA_PATH, mnemonic, noSync)
+      NitroArk.boardAll(noSync)
     );
   };
 
@@ -382,14 +372,7 @@ export default function ArkApp() {
     // Use comment from state, pass null if empty
     const commentToSend = comment.trim() === '' ? null : comment.trim();
     runOperation(`send (Ark) (noSync: ${noSync})`, () =>
-      NitroArk.send(
-        ARK_DATA_PATH,
-        mnemonic,
-        destinationAddress,
-        amountNum,
-        commentToSend,
-        noSync
-      )
+      NitroArk.send(destinationAddress, amountNum, commentToSend, noSync)
     );
   };
 
@@ -404,13 +387,7 @@ export default function ArkApp() {
       return;
     }
     runOperation(`sendRoundOnchain (noSync: ${noSync})`, () =>
-      NitroArk.sendRoundOnchain(
-        ARK_DATA_PATH,
-        mnemonic,
-        destinationAddress,
-        amountNum,
-        noSync
-      )
+      NitroArk.sendRoundOnchain(destinationAddress, amountNum, noSync)
     );
   };
 
@@ -430,13 +407,7 @@ export default function ArkApp() {
     const addrToSend =
       optionalAddress.trim() === '' ? null : optionalAddress.trim();
     runOperation(`offboardSpecific (noSync: ${noSync})`, () =>
-      NitroArk.offboardSpecific(
-        ARK_DATA_PATH,
-        mnemonic,
-        ids,
-        addrToSend,
-        noSync
-      )
+      NitroArk.offboardSpecific(ids, addrToSend, noSync)
     );
   };
 
@@ -448,7 +419,7 @@ export default function ArkApp() {
     const addrToSend =
       optionalAddress.trim() === '' ? null : optionalAddress.trim();
     runOperation(`offboardAll (noSync: ${noSync})`, () =>
-      NitroArk.offboardAll(ARK_DATA_PATH, mnemonic, addrToSend, noSync)
+      NitroArk.offboardAll(addrToSend, noSync)
     );
   };
 
@@ -466,7 +437,7 @@ export default function ArkApp() {
       return;
     }
     runOperation(`exitStartSpecific (noSync: ${noSync})`, () =>
-      NitroArk.exitStartSpecific(ARK_DATA_PATH, mnemonic, ids, noSync)
+      NitroArk.exitStartSpecific(ids)
     );
   };
 
@@ -476,7 +447,7 @@ export default function ArkApp() {
       return;
     }
     runOperation(`exitStartAll (noSync: ${noSync})`, () =>
-      NitroArk.exitStartAll(ARK_DATA_PATH, mnemonic, noSync)
+      NitroArk.exitStartAll()
     );
   };
 
@@ -485,9 +456,7 @@ export default function ArkApp() {
       setError('Mnemonic required');
       return;
     }
-    runOperation('exitProgressOnce', () =>
-      NitroArk.exitProgressOnce(ARK_DATA_PATH, mnemonic)
-    );
+    runOperation('exitProgressOnce', () => NitroArk.exitProgressOnce());
   };
 
   const handleCreateInvoice = () => {
@@ -502,7 +471,7 @@ export default function ArkApp() {
     }
     runOperation(
       'bolt11Invoice',
-      () => NitroArk.bolt11Invoice(ARK_DATA_PATH, mnemonic, amount),
+      () => NitroArk.bolt11Invoice(amount),
       (invoice) => {
         setResults(`Created Invoice: ${invoice}`);
         setInvoiceToClaim(invoice);
@@ -521,8 +490,7 @@ export default function ArkApp() {
     }
     runOperation(
       'claimBolt11Payment',
-      () =>
-        NitroArk.claimBolt11Payment(ARK_DATA_PATH, mnemonic, invoiceToClaim),
+      () => NitroArk.claimBolt11Payment(invoiceToClaim),
       () => {
         setResults('Successfully claimed payment!');
       }

--- a/react-native-nitro-ark/example/src/App.tsx
+++ b/react-native-nitro-ark/example/src/App.tsx
@@ -10,11 +10,7 @@ import {
   TextInput,
   ActivityIndicator,
 } from 'react-native';
-import {
-  DocumentDirectoryPath,
-  exists,
-  mkdir,
-} from '@dr.pogodin/react-native-fs';
+import { DocumentDirectoryPath } from '@dr.pogodin/react-native-fs';
 import * as NitroArk from 'react-native-nitro-ark';
 import type {
   BarkBalance,
@@ -55,25 +51,25 @@ export default function ArkApp() {
   const [invoiceToClaim, setInvoiceToClaim] = useState('');
 
   // Ensure data directory exists on mount
-  useEffect(() => {
-    const setupDirectory = async () => {
-      try {
-        const dirExists = await exists(ARK_DATA_PATH);
-        if (!dirExists) {
-          await mkdir(ARK_DATA_PATH, {
-            NSURLIsExcludedFromBackupKey: true, // iOS specific
-          });
-          console.log('Data directory created:', ARK_DATA_PATH);
-        } else {
-          console.log('Data directory exists:', ARK_DATA_PATH);
-        }
-      } catch (err: any) {
-        console.error('Error setting up data directory:', err);
-        setError(`Failed to setup data directory: ${err.message}`);
-      }
-    };
-    setupDirectory();
-  }, []);
+  // useEffect(() => {
+  //   const setupDirectory = async () => {
+  //     try {
+  //       const dirExists = await exists(ARK_DATA_PATH);
+  //       if (!dirExists) {
+  //         await mkdir(ARK_DATA_PATH, {
+  //           NSURLIsExcludedFromBackupKey: true, // iOS specific
+  //         });
+  //         console.log('Data directory created:', ARK_DATA_PATH);
+  //       } else {
+  //         console.log('Data directory exists:', ARK_DATA_PATH);
+  //       }
+  //     } catch (err: any) {
+  //       console.error('Error setting up data directory:', err);
+  //       setError(`Failed to setup data directory: ${err.message}`);
+  //     }
+  //   };
+  //   setupDirectory();
+  // }, []);
 
   useEffect(() => {
     const loadSavedMnemonic = async () => {
@@ -167,33 +163,35 @@ export default function ArkApp() {
       setError('Mnemonic is required to create a wallet.');
       return;
     }
-    // const opts: NitroArk.BarkCreateOpts = {
-    //   mnemonic: mnemonic,
-    //   force: true,
-    //   regtest: true,
-    //   signet: false,
-    //   bitcoin: false,
-    //   config: {
-    //     bitcoind: 'http://192.168.4.253:18443',
-    //     asp: 'http://192.168.4.253:3535',
-    //     bitcoind_user: 'polaruser',
-    //     bitcoind_pass: 'polarpass',
-    //     vtxo_refresh_expiry_threshold: 288,
-    //   },
-    // };
-
     const opts: NitroArk.BarkCreateOpts = {
       mnemonic: mnemonic,
       force: true,
-      regtest: false,
-      signet: true,
+      regtest: true,
+      signet: false,
       bitcoin: false,
       config: {
-        esplora: 'esplora.signet.2nd.dev',
-        asp: 'ark.signet.2nd.dev',
+        bitcoind: 'http://192.168.4.252:18443',
+        asp: 'http://192.168.4.252:3535',
+        bitcoind_user: 'polaruser',
+        bitcoind_pass: 'polarpass',
         vtxo_refresh_expiry_threshold: 288,
+        fallback_fee_rate: 100000,
       },
     };
+
+    // const opts: NitroArk.BarkCreateOpts = {
+    //   mnemonic: mnemonic,
+    //   force: true,
+    //   regtest: false,
+    //   signet: true,
+    //   bitcoin: false,
+    //   config: {
+    //     esplora: 'esplora.signet.2nd.dev',
+    //     asp: 'ark.signet.2nd.dev',
+    //     vtxo_refresh_expiry_threshold: 288,
+    //     fallback_fee_rate: 100000,
+    //   },
+    // };
     runOperation(
       'loadWallet',
       () => NitroArk.loadWallet(ARK_DATA_PATH, opts),
@@ -201,6 +199,10 @@ export default function ArkApp() {
         setResults('Wallet created successfully!');
       }
     );
+  };
+
+  const handleCloseWallet = () => {
+    runOperation('closeWallet', () => NitroArk.closeWallet());
   };
 
   const handleGetBalance = (noSync: boolean) => {
@@ -538,6 +540,14 @@ export default function ArkApp() {
           <Button
             title="Create Wallet"
             onPress={handleCreateWallet}
+            disabled={isLoading || !mnemonic} // Disable if no mnemonic or already created
+          />
+        </View>
+
+        <View style={styles.buttonContainer}>
+          <Button
+            title="Close Wallet"
+            onPress={handleCloseWallet}
             disabled={isLoading || !mnemonic} // Disable if no mnemonic or already created
           />
         </View>

--- a/react-native-nitro-ark/nitrogen/generated/shared/c++/HybridNitroArkSpec.cpp
+++ b/react-native-nitro-ark/nitrogen/generated/shared/c++/HybridNitroArkSpec.cpp
@@ -15,7 +15,8 @@ namespace margelo::nitro::nitroark {
     // load custom methods/properties
     registerHybrids(this, [](Prototype& prototype) {
       prototype.registerHybridMethod("createMnemonic", &HybridNitroArkSpec::createMnemonic);
-      prototype.registerHybridMethod("createWallet", &HybridNitroArkSpec::createWallet);
+      prototype.registerHybridMethod("loadWallet", &HybridNitroArkSpec::loadWallet);
+      prototype.registerHybridMethod("closeWallet", &HybridNitroArkSpec::closeWallet);
       prototype.registerHybridMethod("getBalance", &HybridNitroArkSpec::getBalance);
       prototype.registerHybridMethod("getOnchainAddress", &HybridNitroArkSpec::getOnchainAddress);
       prototype.registerHybridMethod("getOnchainUtxos", &HybridNitroArkSpec::getOnchainUtxos);

--- a/react-native-nitro-ark/nitrogen/generated/shared/c++/HybridNitroArkSpec.hpp
+++ b/react-native-nitro-ark/nitrogen/generated/shared/c++/HybridNitroArkSpec.hpp
@@ -26,10 +26,10 @@ namespace margelo::nitro::nitroark { struct BarkRefreshOpts; }
 #include <string>
 #include "BarkCreateOpts.hpp"
 #include "BarkBalance.hpp"
+#include <optional>
 #include <vector>
 #include "BarkSendManyOutput.hpp"
 #include "BarkRefreshOpts.hpp"
-#include <optional>
 
 namespace margelo::nitro::nitroark {
 
@@ -63,27 +63,28 @@ namespace margelo::nitro::nitroark {
     public:
       // Methods
       virtual std::shared_ptr<Promise<std::string>> createMnemonic() = 0;
-      virtual std::shared_ptr<Promise<void>> createWallet(const std::string& datadir, const BarkCreateOpts& opts) = 0;
-      virtual std::shared_ptr<Promise<BarkBalance>> getBalance(const std::string& datadir, bool no_sync, const std::string& mnemonic) = 0;
-      virtual std::shared_ptr<Promise<std::string>> getOnchainAddress(const std::string& datadir, const std::string& mnemonic) = 0;
-      virtual std::shared_ptr<Promise<std::string>> getOnchainUtxos(const std::string& datadir, const std::string& mnemonic, bool no_sync) = 0;
-      virtual std::shared_ptr<Promise<std::string>> getVtxoPubkey(const std::string& datadir, const std::string& mnemonic) = 0;
-      virtual std::shared_ptr<Promise<std::string>> getVtxos(const std::string& datadir, const std::string& mnemonic, bool no_sync) = 0;
-      virtual std::shared_ptr<Promise<std::string>> sendOnchain(const std::string& datadir, const std::string& mnemonic, const std::string& destination, double amountSat, bool no_sync) = 0;
-      virtual std::shared_ptr<Promise<std::string>> drainOnchain(const std::string& datadir, const std::string& mnemonic, const std::string& destination, bool no_sync) = 0;
-      virtual std::shared_ptr<Promise<std::string>> sendManyOnchain(const std::string& datadir, const std::string& mnemonic, const std::vector<BarkSendManyOutput>& outputs, bool no_sync) = 0;
-      virtual std::shared_ptr<Promise<std::string>> refreshVtxos(const std::string& datadir, const std::string& mnemonic, const BarkRefreshOpts& refreshOpts, bool no_sync) = 0;
-      virtual std::shared_ptr<Promise<std::string>> boardAmount(const std::string& datadir, const std::string& mnemonic, double amountSat, bool no_sync) = 0;
-      virtual std::shared_ptr<Promise<std::string>> boardAll(const std::string& datadir, const std::string& mnemonic, bool no_sync) = 0;
-      virtual std::shared_ptr<Promise<std::string>> send(const std::string& datadir, const std::string& mnemonic, const std::string& destination, double amountSat, const std::optional<std::string>& comment, bool no_sync) = 0;
-      virtual std::shared_ptr<Promise<std::string>> sendRoundOnchain(const std::string& datadir, const std::string& mnemonic, const std::string& destination, double amountSat, bool no_sync) = 0;
-      virtual std::shared_ptr<Promise<std::string>> bolt11Invoice(const std::string& datadir, const std::string& mnemonic, double amountSat) = 0;
-      virtual std::shared_ptr<Promise<void>> claimBolt11Payment(const std::string& datadir, const std::string& mnemonic, const std::string& bolt11) = 0;
-      virtual std::shared_ptr<Promise<std::string>> offboardSpecific(const std::string& datadir, const std::string& mnemonic, const std::vector<std::string>& vtxoIds, const std::optional<std::string>& optionalAddress, bool no_sync) = 0;
-      virtual std::shared_ptr<Promise<std::string>> offboardAll(const std::string& datadir, const std::string& mnemonic, const std::optional<std::string>& optionalAddress, bool no_sync) = 0;
-      virtual std::shared_ptr<Promise<std::string>> exitStartSpecific(const std::string& datadir, const std::string& mnemonic, const std::vector<std::string>& vtxoIds, bool no_sync) = 0;
-      virtual std::shared_ptr<Promise<std::string>> exitStartAll(const std::string& datadir, const std::string& mnemonic, bool no_sync) = 0;
-      virtual std::shared_ptr<Promise<std::string>> exitProgressOnce(const std::string& datadir, const std::string& mnemonic) = 0;
+      virtual std::shared_ptr<Promise<void>> loadWallet(const std::string& datadir, const BarkCreateOpts& opts) = 0;
+      virtual std::shared_ptr<Promise<void>> closeWallet() = 0;
+      virtual std::shared_ptr<Promise<BarkBalance>> getBalance(bool no_sync) = 0;
+      virtual std::shared_ptr<Promise<std::string>> getOnchainAddress() = 0;
+      virtual std::shared_ptr<Promise<std::string>> getOnchainUtxos(bool no_sync) = 0;
+      virtual std::shared_ptr<Promise<std::string>> getVtxoPubkey(std::optional<double> index) = 0;
+      virtual std::shared_ptr<Promise<std::string>> getVtxos(bool no_sync) = 0;
+      virtual std::shared_ptr<Promise<std::string>> sendOnchain(const std::string& destination, double amountSat, bool no_sync) = 0;
+      virtual std::shared_ptr<Promise<std::string>> drainOnchain(const std::string& destination, bool no_sync) = 0;
+      virtual std::shared_ptr<Promise<std::string>> sendManyOnchain(const std::vector<BarkSendManyOutput>& outputs, bool no_sync) = 0;
+      virtual std::shared_ptr<Promise<std::string>> refreshVtxos(const BarkRefreshOpts& refreshOpts, bool no_sync) = 0;
+      virtual std::shared_ptr<Promise<std::string>> boardAmount(double amountSat, bool no_sync) = 0;
+      virtual std::shared_ptr<Promise<std::string>> boardAll(bool no_sync) = 0;
+      virtual std::shared_ptr<Promise<std::string>> send(const std::string& destination, double amountSat, const std::optional<std::string>& comment, bool no_sync) = 0;
+      virtual std::shared_ptr<Promise<std::string>> sendRoundOnchain(const std::string& destination, double amountSat, bool no_sync) = 0;
+      virtual std::shared_ptr<Promise<std::string>> bolt11Invoice(double amountMsat) = 0;
+      virtual std::shared_ptr<Promise<void>> claimBolt11Payment(const std::string& bolt11) = 0;
+      virtual std::shared_ptr<Promise<std::string>> offboardSpecific(const std::vector<std::string>& vtxoIds, const std::optional<std::string>& optionalAddress, bool no_sync) = 0;
+      virtual std::shared_ptr<Promise<std::string>> offboardAll(const std::optional<std::string>& optionalAddress, bool no_sync) = 0;
+      virtual std::shared_ptr<Promise<std::string>> exitStartSpecific(const std::vector<std::string>& vtxoIds) = 0;
+      virtual std::shared_ptr<Promise<std::string>> exitStartAll() = 0;
+      virtual std::shared_ptr<Promise<std::string>> exitProgressOnce() = 0;
 
     protected:
       // Hybrid Setup

--- a/react-native-nitro-ark/src/NitroArk.nitro.ts
+++ b/react-native-nitro-ark/src/NitroArk.nitro.ts
@@ -56,118 +56,59 @@ export interface BarkSendManyOutput {
 export interface NitroArk extends HybridObject<{ ios: 'c++'; android: 'c++' }> {
   // --- Management ---
   createMnemonic(): Promise<string>;
-  createWallet(datadir: string, opts: BarkCreateOpts): Promise<void>; // Returns void on success, throws on error
+  loadWallet(datadir: string, opts: BarkCreateOpts): Promise<void>;
+  closeWallet(): Promise<void>;
 
   // --- Wallet Info ---
-  getBalance(
-    datadir: string,
-    no_sync: boolean,
-    mnemonic: string
-  ): Promise<BarkBalance>;
-  getOnchainAddress(datadir: string, mnemonic: string): Promise<string>;
-  getOnchainUtxos(
-    datadir: string,
-    mnemonic: string,
-    no_sync: boolean
-  ): Promise<string>; // Returns JSON string
-  getVtxoPubkey(datadir: string, mnemonic: string): Promise<string>;
-  getVtxos(
-    datadir: string,
-    mnemonic: string,
-    no_sync: boolean
-  ): Promise<string>; // Returns JSON string
+  getBalance(no_sync: boolean): Promise<BarkBalance>;
+  getOnchainAddress(): Promise<string>;
+  getOnchainUtxos(no_sync: boolean): Promise<string>; // Returns JSON string
+  getVtxoPubkey(index?: number): Promise<string>;
+  getVtxos(no_sync: boolean): Promise<string>; // Returns JSON string
 
   // --- Onchain Operations ---
   sendOnchain(
-    datadir: string,
-    mnemonic: string,
     destination: string,
     amountSat: number,
     no_sync: boolean
   ): Promise<string>; // Returns txid
-  drainOnchain(
-    datadir: string,
-    mnemonic: string,
-    destination: string,
-    no_sync: boolean
-  ): Promise<string>; // Returns txid
+  drainOnchain(destination: string, no_sync: boolean): Promise<string>; // Returns txid
   sendManyOnchain(
-    datadir: string,
-    mnemonic: string,
     outputs: BarkSendManyOutput[],
     no_sync: boolean
   ): Promise<string>; // Returns txid
 
   // --- Ark Operations ---
-  refreshVtxos(
-    datadir: string,
-    mnemonic: string,
-    refreshOpts: BarkRefreshOpts,
-    no_sync: boolean
-  ): Promise<string>; // Returns JSON status
-  boardAmount(
-    datadir: string,
-    mnemonic: string,
-    amountSat: number,
-    no_sync: boolean
-  ): Promise<string>; // Returns JSON status
-  boardAll(
-    datadir: string,
-    mnemonic: string,
-    no_sync: boolean
-  ): Promise<string>; // Returns JSON status
+  refreshVtxos(refreshOpts: BarkRefreshOpts, no_sync: boolean): Promise<string>; // Returns JSON status
+  boardAmount(amountSat: number, no_sync: boolean): Promise<string>; // Returns JSON status
+  boardAll(no_sync: boolean): Promise<string>; // Returns JSON status
   send(
-    datadir: string,
-    mnemonic: string,
     destination: string,
     amountSat: number,
     comment: string | null,
     no_sync: boolean
   ): Promise<string>; // Returns JSON status
   sendRoundOnchain(
-    datadir: string,
-    mnemonic: string,
     destination: string,
     amountSat: number,
     no_sync: boolean
   ): Promise<string>; // Returns JSON status
 
   // --- Lightning Operations ---
-  bolt11Invoice(
-    datadir: string,
-    mnemonic: string,
-    amountSat: number
-  ): Promise<string>; // Returns invoice string
-  claimBolt11Payment(
-    datadir: string,
-    mnemonic: string,
-    bolt11: string
-  ): Promise<void>; // Throws on error
+  bolt11Invoice(amountMsat: number): Promise<string>; // Returns invoice string
+  claimBolt11Payment(bolt11: string): Promise<void>; // Throws on error
 
   // --- Offboarding / Exiting ---
   offboardSpecific(
-    datadir: string,
-    mnemonic: string,
     vtxoIds: string[],
     optionalAddress: string | null,
     no_sync: boolean
   ): Promise<string>; // Returns JSON result
   offboardAll(
-    datadir: string,
-    mnemonic: string,
     optionalAddress: string | null,
     no_sync: boolean
   ): Promise<string>; // Returns JSON result
-  exitStartSpecific(
-    datadir: string,
-    mnemonic: string,
-    vtxoIds: string[],
-    no_sync: boolean
-  ): Promise<string>; // Returns JSON status
-  exitStartAll(
-    datadir: string,
-    mnemonic: string,
-    no_sync: boolean
-  ): Promise<string>; // Returns JSON status
-  exitProgressOnce(datadir: string, mnemonic: string): Promise<string>; // Returns JSON status
+  exitStartSpecific(vtxoIds: string[]): Promise<string>; // Returns JSON status
+  exitStartAll(): Promise<string>; // Returns JSON status
+  exitProgressOnce(): Promise<string>; // Returns JSON status
 }

--- a/react-native-nitro-ark/src/index.tsx
+++ b/react-native-nitro-ark/src/index.tsx
@@ -22,226 +22,153 @@ export function createMnemonic(): Promise<string> {
 }
 
 /**
- * Creates a new wallet at the specified directory.
+ * Loads an existing wallet or creates a new one at the specified directory.
+ * Once loaded, the wallet state is managed internally.
  * @param datadir Path to the data directory.
- * @param opts Creation options.
+ * @param opts Creation and configuration options.
  * @returns A promise that resolves on success or rejects on error.
  */
-export function createWallet(
+export function loadWallet(
   datadir: string,
   opts: BarkCreateOpts
 ): Promise<void> {
-  return NitroArkHybridObject.createWallet(datadir, opts);
+  return NitroArkHybridObject.loadWallet(datadir, opts);
+}
+
+/**
+ * Closes the currently loaded wallet, clearing its state from memory.
+ * @returns A promise that resolves on success or rejects on error.
+ */
+export function closeWallet(): Promise<void> {
+  return NitroArkHybridObject.closeWallet();
 }
 
 // --- Wallet Info ---
 
 /**
- * Gets the offchain and onchain balances.
- * @param datadir Path to the data directory.
- * @param no_sync Whether to skip syncing the wallet. Defaults to false.
- * @param mnemonic The wallet mnemonic phrase.
+ * Gets the onchain and offchain balances for the loaded wallet.
+ * @param no_sync If true, skips synchronization with the blockchain. Defaults to false.
  * @returns A promise resolving to the BarkBalance object.
  */
-export function getBalance(
-  datadir: string,
-  mnemonic: string,
-  no_sync: boolean = false
-): Promise<BarkBalance> {
-  // Pass mnemonic correctly, adjusted default position for optional no_sync
-  return NitroArkHybridObject.getBalance(datadir, no_sync, mnemonic);
+export function getBalance(no_sync: boolean = false): Promise<BarkBalance> {
+  return NitroArkHybridObject.getBalance(no_sync);
 }
 
 /**
- * Gets a fresh onchain address.
- * @param datadir Path to the data directory.
- * @param mnemonic The wallet mnemonic phrase.
+ * Gets a fresh onchain address for the loaded wallet.
  * @returns A promise resolving to the Bitcoin address string.
  */
-export function getOnchainAddress(
-  datadir: string,
-  mnemonic: string
-): Promise<string> {
-  return NitroArkHybridObject.getOnchainAddress(datadir, mnemonic);
+export function getOnchainAddress(): Promise<string> {
+  return NitroArkHybridObject.getOnchainAddress();
 }
 
 /**
- * Gets the list of onchain UTXOs as a JSON string.
- * @param datadir Path to the data directory.
- * @param mnemonic The wallet mnemonic phrase.
- * @param no_sync Whether to skip syncing the wallet. Defaults to false.
+ * Gets the list of onchain UTXOs as a JSON string for the loaded wallet.
+ * @param no_sync If true, skips synchronization with the blockchain. Defaults to false.
  * @returns A promise resolving to the JSON string of UTXOs.
  */
-export function getOnchainUtxos(
-  datadir: string,
-  mnemonic: string,
-  no_sync: boolean = false
-): Promise<string> {
-  return NitroArkHybridObject.getOnchainUtxos(datadir, mnemonic, no_sync);
+export function getOnchainUtxos(no_sync: boolean = false): Promise<string> {
+  return NitroArkHybridObject.getOnchainUtxos(no_sync);
 }
 
 /**
  * Gets the wallet's VTXO public key (hex string).
- * @param datadir Path to the data directory.
- * @param mnemonic The wallet mnemonic phrase.
+ * @param index Optional index of the VTXO pubkey to retrieve.
  * @returns A promise resolving to the hex-encoded public key string.
  */
-export function getVtxoPubkey(
-  datadir: string,
-  mnemonic: string
-): Promise<string> {
-  return NitroArkHybridObject.getVtxoPubkey(datadir, mnemonic);
+export function getVtxoPubkey(index?: number): Promise<string> {
+  return NitroArkHybridObject.getVtxoPubkey(index);
 }
 
 /**
- * Gets the list of VTXOs as a JSON string.
- * @param datadir Path to the data directory.
- * @param mnemonic The wallet mnemonic phrase.
- * @param no_sync Whether to skip syncing the wallet. Defaults to false.
+ * Gets the list of VTXOs as a JSON string for the loaded wallet.
+ * @param no_sync If true, skips synchronization with the blockchain. Defaults to false.
  * @returns A promise resolving to the JSON string of VTXOs.
  */
-export function getVtxos(
-  datadir: string,
-  mnemonic: string,
-  no_sync: boolean = false
-): Promise<string> {
-  return NitroArkHybridObject.getVtxos(datadir, mnemonic, no_sync);
+export function getVtxos(no_sync: boolean = false): Promise<string> {
+  return NitroArkHybridObject.getVtxos(no_sync);
 }
 
 // --- Onchain Operations ---
 
 /**
  * Sends funds using the onchain wallet.
- * @param datadir Path to the data directory.
- * @param mnemonic The wallet mnemonic phrase.
  * @param destination The destination Bitcoin address.
  * @param amountSat The amount to send in satoshis.
- * @param no_sync Whether to skip syncing the wallet. Defaults to false.
+ * @param no_sync If true, skips synchronization with the blockchain. Defaults to false.
  * @returns A promise resolving to the transaction ID string.
  */
 export function sendOnchain(
-  datadir: string,
-  mnemonic: string,
   destination: string,
   amountSat: number,
   no_sync: boolean = false
 ): Promise<string> {
-  return NitroArkHybridObject.sendOnchain(
-    datadir,
-    mnemonic,
-    destination,
-    amountSat,
-    no_sync
-  );
+  return NitroArkHybridObject.sendOnchain(destination, amountSat, no_sync);
 }
 
 /**
  * Sends all funds from the onchain wallet to a destination address.
- * @param datadir Path to the data directory.
- * @param mnemonic The wallet mnemonic phrase.
  * @param destination The destination Bitcoin address.
- * @param no_sync Whether to skip syncing the wallet. Defaults to false.
+ * @param no_sync If true, skips synchronization with the blockchain. Defaults to false.
  * @returns A promise resolving to the transaction ID string.
  */
 export function drainOnchain(
-  datadir: string,
-  mnemonic: string,
   destination: string,
   no_sync: boolean = false
 ): Promise<string> {
-  return NitroArkHybridObject.drainOnchain(
-    datadir,
-    mnemonic,
-    destination,
-    no_sync
-  );
+  return NitroArkHybridObject.drainOnchain(destination, no_sync);
 }
 
 /**
  * Sends funds to multiple recipients using the onchain wallet.
- * @param datadir Path to the data directory.
- * @param mnemonic The wallet mnemonic phrase.
  * @param outputs An array of objects containing destination address and amountSat.
- * @param no_sync Whether to skip syncing the wallet. Defaults to false.
+ * @param no_sync If true, skips synchronization with the blockchain. Defaults to false.
  * @returns A promise resolving to the transaction ID string.
  */
 export function sendManyOnchain(
-  datadir: string,
-  mnemonic: string,
   outputs: BarkSendManyOutput[],
   no_sync: boolean = false
 ): Promise<string> {
-  return NitroArkHybridObject.sendManyOnchain(
-    datadir,
-    mnemonic,
-    outputs,
-    no_sync
-  );
+  return NitroArkHybridObject.sendManyOnchain(outputs, no_sync);
 }
 
 // --- Lightning Operations ---
 
 /**
  * Creates a Bolt 11 invoice.
- * @param datadir Path to the data directory.
- * @param mnemonic The wallet mnemonic phrase.
- * @param amountSat The amount in satoshis for the invoice.
+ * @param amountMsat The amount in millisatoshis for the invoice.
  * @returns A promise resolving to the Bolt 11 invoice string.
  */
-export function bolt11Invoice(
-  datadir: string,
-  mnemonic: string,
-  amountSat: number
-): Promise<string> {
-  return NitroArkHybridObject.bolt11Invoice(datadir, mnemonic, amountSat);
+export function bolt11Invoice(amountMsat: number): Promise<string> {
+  return NitroArkHybridObject.bolt11Invoice(amountMsat);
 }
 
 /**
  * Claims a Bolt 11 payment.
- * @param datadir Path to the data directory.
- * @param mnemonic The wallet mnemonic phrase.
  * @param bolt11 The Bolt 11 invoice string to claim.
  * @returns A promise that resolves on success or rejects on error.
  */
-export function claimBolt11Payment(
-  datadir: string,
-  mnemonic: string,
-  bolt11: string
-): Promise<void> {
-  return NitroArkHybridObject.claimBolt11Payment(datadir, mnemonic, bolt11);
+export function claimBolt11Payment(bolt11: string): Promise<void> {
+  return NitroArkHybridObject.claimBolt11Payment(bolt11);
 }
 
 // --- Ark Operations ---
 
 /**
- * Refreshes VTXOs based on specified criteria.
- * @param datadir Path to the data directory.
- * @param mnemonic The wallet mnemonic phrase.
+ * Refreshes VTXOs based on specified criteria for the loaded wallet.
  * @param refreshOpts Options specifying which VTXOs to refresh.
- *                    `mode_type` should be one of: 'DefaultThreshold', 'ThresholdBlocks', 'ThresholdHours', 'Counterparty', 'All', 'Specific'.
- * @param no_sync Whether to skip syncing the wallet. Defaults to false.
+ * @param no_sync If true, skips synchronization with the blockchain. Defaults to false.
  * @returns A promise resolving to a JSON status string.
- * @example
- * // Refresh using default threshold
- * refreshVtxos(datadir, mnemonic, { mode_type: 'DefaultThreshold' });
- * // Refresh specific VTXOs
- * refreshVtxos(datadir, mnemonic, { mode_type: 'Specific', specific_vtxo_ids: ['vtxo_id_1', 'vtxo_id_2'] });
- * // Refresh if older than 10 blocks
- * refreshVtxos(datadir, mnemonic, { mode_type: 'ThresholdBlocks', threshold_value: 10 });
  */
 export function refreshVtxos(
-  datadir: string,
-  mnemonic: string,
   refreshOpts: BarkRefreshOpts,
   no_sync: boolean = false
 ): Promise<string> {
-  // Ensure mode_type is provided (should be handled by TS type system)
   if (!refreshOpts.mode_type) {
     return Promise.reject(
       new Error('refreshVtxos requires refreshOpts.mode_type')
     );
   }
-  // Additional validation for specific modes could be added here if desired
   if (
     refreshOpts.mode_type === 'Specific' &&
     (!refreshOpts.specific_vtxo_ids ||
@@ -265,125 +192,78 @@ export function refreshVtxos(
       )
     );
   }
-  return NitroArkHybridObject.refreshVtxos(
-    datadir,
-    mnemonic,
-    refreshOpts,
-    no_sync
-  );
+  return NitroArkHybridObject.refreshVtxos(refreshOpts, no_sync);
 }
 
 /**
  * Boards a specific amount from the onchain wallet into Ark.
- * @param datadir Path to the data directory.
- * @param mnemonic The wallet mnemonic phrase.
  * @param amountSat The amount in satoshis to board.
- * @param no_sync Whether to skip syncing the onchain wallet. Defaults to false.
+ * @param no_sync If true, skips synchronization with the onchain wallet. Defaults to false.
  * @returns A promise resolving to a JSON status string.
  */
 export function boardAmount(
-  datadir: string,
-  mnemonic: string,
   amountSat: number,
   no_sync: boolean = false
 ): Promise<string> {
-  return NitroArkHybridObject.boardAmount(
-    datadir,
-    mnemonic,
-    amountSat,
-    no_sync
-  );
+  return NitroArkHybridObject.boardAmount(amountSat, no_sync);
 }
 
 /**
  * Boards all available funds from the onchain wallet into Ark.
- * @param datadir Path to the data directory.
- * @param mnemonic The wallet mnemonic phrase.
- * @param no_sync Whether to skip syncing the onchain wallet. Defaults to false.
+ * @param no_sync If true, skips synchronization with the onchain wallet. Defaults to false.
  * @returns A promise resolving to a JSON status string.
  */
-export function boardAll(
-  datadir: string,
-  mnemonic: string,
-  no_sync: boolean = false
-): Promise<string> {
-  return NitroArkHybridObject.boardAll(datadir, mnemonic, no_sync);
+export function boardAll(no_sync: boolean = false): Promise<string> {
+  return NitroArkHybridObject.boardAll(no_sync);
 }
 
 /**
  * Sends funds offchain using Ark VTXOs.
- * @param datadir Path to the data directory.
- * @param mnemonic The wallet mnemonic phrase.
  * @param destination Ark address (VTXO pubkey) or onchain Bitcoin address.
  * @param amountSat The amount in satoshis to send.
- * @param comment Optional comment (can be null).
- * @param no_sync Whether to skip syncing the wallet. Defaults to false.
+ * @param comment Optional comment.
+ * @param no_sync If true, skips synchronization with the wallet. Defaults to false.
  * @returns A promise resolving to a JSON status string.
  */
 export function send(
-  datadir: string,
-  mnemonic: string,
   destination: string,
   amountSat: number,
   comment: string | null = null,
   no_sync: boolean = false
 ): Promise<string> {
-  return NitroArkHybridObject.send(
-    datadir,
-    mnemonic,
-    destination,
-    amountSat,
-    comment,
-    no_sync
-  );
+  return NitroArkHybridObject.send(destination, amountSat, comment, no_sync);
 }
 
 /**
  * Sends an onchain payment via an Ark round.
- * @param datadir Path to the data directory.
- * @param mnemonic The wallet mnemonic phrase.
  * @param destination The destination Bitcoin address.
  * @param amountSat The amount in satoshis to send.
- * @param no_sync Whether to skip syncing the wallet. Defaults to false.
+ * @param no_sync If true, skips synchronization with the wallet. Defaults to false.
  * @returns A promise resolving to a JSON status string.
  */
 export function sendRoundOnchain(
-  datadir: string,
-  mnemonic: string,
   destination: string,
   amountSat: number,
   no_sync: boolean = false
 ): Promise<string> {
-  return NitroArkHybridObject.sendRoundOnchain(
-    datadir,
-    mnemonic,
-    destination,
-    amountSat,
-    no_sync
-  );
+  return NitroArkHybridObject.sendRoundOnchain(destination, amountSat, no_sync);
 }
 
 // --- Offboarding / Exiting ---
 
 /**
  * Offboards specific VTXOs to an optional onchain address.
- * @param datadir Path to the data directory.
- * @param mnemonic The wallet mnemonic phrase.
  * @param vtxoIds Array of VtxoId strings to offboard.
  * @param optionalAddress Optional destination Bitcoin address (null if sending to internal wallet).
- * @param no_sync Whether to skip syncing the wallet. Defaults to false.
+ * @param no_sync If true, skips synchronization with the wallet. Defaults to false.
  * @returns A promise resolving to a JSON result string.
  */
 export function offboardSpecific(
-  datadir: string,
-  mnemonic: string,
   vtxoIds: string[],
   optionalAddress: string | null = null,
   no_sync: boolean = false
 ): Promise<string> {
   return NitroArkHybridObject.offboardSpecific(
-    datadir,
-    mnemonic,
     vtxoIds,
     optionalAddress,
     no_sync
@@ -392,76 +272,40 @@ export function offboardSpecific(
 
 /**
  * Offboards all VTXOs to an optional onchain address.
- * @param datadir Path to the data directory.
- * @param mnemonic The wallet mnemonic phrase.
  * @param optionalAddress Optional destination Bitcoin address (null if sending to internal wallet).
- * @param no_sync Whether to skip syncing the wallet. Defaults to false.
+ * @param no_sync If true, skips synchronization with the wallet. Defaults to false.
  * @returns A promise resolving to a JSON result string.
  */
 export function offboardAll(
-  datadir: string,
-  mnemonic: string,
   optionalAddress: string | null = null,
   no_sync: boolean = false
 ): Promise<string> {
-  return NitroArkHybridObject.offboardAll(
-    datadir,
-    mnemonic,
-    optionalAddress,
-    no_sync
-  );
+  return NitroArkHybridObject.offboardAll(optionalAddress, no_sync);
 }
 
 /**
  * Starts the exit process for specific VTXOs.
- * @param datadir Path to the data directory.
- * @param mnemonic The wallet mnemonic phrase.
  * @param vtxoIds Array of VtxoId strings to start exiting.
- * @param no_sync Whether to skip syncing the wallet (Note: This might depend on potential C header updates). Defaults to false.
  * @returns A promise resolving to a JSON status string.
  */
-export function exitStartSpecific(
-  datadir: string,
-  mnemonic: string,
-  vtxoIds: string[],
-  no_sync: boolean = false
-): Promise<string> {
-  // Passing no_sync, aligning with the TS/C++ interface definition, even if C header might differ
-  return NitroArkHybridObject.exitStartSpecific(
-    datadir,
-    mnemonic,
-    vtxoIds,
-    no_sync
-  );
+export function exitStartSpecific(vtxoIds: string[]): Promise<string> {
+  return NitroArkHybridObject.exitStartSpecific(vtxoIds);
 }
 
 /**
  * Starts the exit process for all VTXOs in the wallet.
- * @param datadir Path to the data directory.
- * @param mnemonic The wallet mnemonic phrase.
- * @param no_sync Whether to skip syncing the wallet (Note: This might depend on potential C header updates). Defaults to false.
  * @returns A promise resolving to a JSON status string.
  */
-export function exitStartAll(
-  datadir: string,
-  mnemonic: string,
-  no_sync: boolean = false
-): Promise<string> {
-  // Passing no_sync, aligning with the TS/C++ interface definition, even if C header might differ
-  return NitroArkHybridObject.exitStartAll(datadir, mnemonic, no_sync);
+export function exitStartAll(): Promise<string> {
+  return NitroArkHybridObject.exitStartAll();
 }
 
 /**
  * Progresses the exit process once and returns the current status.
- * @param datadir Path to the data directory.
- * @param mnemonic The wallet mnemonic phrase.
  * @returns A promise resolving to a JSON status string.
  */
-export function exitProgressOnce(
-  datadir: string,
-  mnemonic: string
-): Promise<string> {
-  return NitroArkHybridObject.exitProgressOnce(datadir, mnemonic);
+export function exitProgressOnce(): Promise<string> {
+  return NitroArkHybridObject.exitProgressOnce();
 }
 
 // --- Re-export types and enums ---


### PR DESCRIPTION
Right now we open and close the wallet for every call to nitro ark, this is very inefficient and it also expects config path and mnemonic every single time. This PR changes that and loads wallet into memory when we call the load wallet method on app startup. 