### PR TITLE
Bump packages and update return types.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -25,5 +25,6 @@
         "__node_handle": "cpp",
         "optional": "cpp",
         "regex": "cpp",
+        "stdexcept": "cpp"
     }
 }

--- a/bark-cpp/src/cxx.rs
+++ b/bark-cpp/src/cxx.rs
@@ -132,7 +132,7 @@ pub(crate) mod ffi {
         fn offboard_specific(vtxo_ids: Vec<String>, destination_address: &str) -> Result<String>;
         fn offboard_all(destination_address: &str) -> Result<String>;
         fn start_exit_for_vtxos(vtxo_ids: Vec<String>) -> Result<String>;
-        fn start_exit_for_entire_wallet() -> Result<String>;
+        fn start_exit_for_entire_wallet() -> Result<()>;
         fn exit_progress_once() -> Result<String>;
     }
 }
@@ -527,7 +527,7 @@ pub(crate) fn start_exit_for_vtxos(vtxo_ids: Vec<String>) -> anyhow::Result<Stri
     crate::TOKIO_RUNTIME.block_on(crate::start_exit_for_vtxos(ids))
 }
 
-pub(crate) fn start_exit_for_entire_wallet() -> anyhow::Result<String> {
+pub(crate) fn start_exit_for_entire_wallet() -> anyhow::Result<()> {
     crate::TOKIO_RUNTIME.block_on(crate::start_exit_for_entire_wallet())
 }
 

--- a/bark-cpp/src/lib.rs
+++ b/bark-cpp/src/lib.rs
@@ -645,7 +645,7 @@ pub async fn start_exit_for_vtxos(vtxo_ids: Vec<VtxoId>) -> anyhow::Result<Strin
 /// Start the exit process for the entire wallet. Returns simple success JSON.
 /// This function starts the exit process for all vtxos in the wallet.
 /// It returns a JSON object indicating success.
-pub async fn start_exit_for_entire_wallet() -> anyhow::Result<String> {
+pub async fn start_exit_for_entire_wallet() -> anyhow::Result<()> {
     let mut wallet_guard = GLOBAL_WALLET.lock().await;
     let w = wallet_guard.as_mut().context("Wallet not loaded")?;
 
@@ -662,11 +662,7 @@ pub async fn start_exit_for_entire_wallet() -> anyhow::Result<String> {
     }
 
     info!("Starting exit process for entire wallet...");
-    w.exit.start_exit_for_entire_wallet(&mut w.onchain).await?;
-
-    let success_json = serde_json::json!({ "success": true, "type": "start_all" });
-    let json_string = serde_json::to_string_pretty(&success_json)?;
-    Ok(json_string)
+    w.exit.start_exit_for_entire_wallet(&mut w.onchain).await
 }
 
 /// This function processes the exit queue for the wallet.

--- a/react-native-nitro-ark/cpp/NitroArk.hpp
+++ b/react-native-nitro-ark/cpp/NitroArk.hpp
@@ -537,14 +537,13 @@ namespace margelo::nitro::nitroark
             } });
         }
 
-        std::shared_ptr<Promise<std::string>>
-        exitStartAll() override
+        std::shared_ptr<Promise<void>>
+        startExitForEntireWallet() override
         {
-            return Promise<std::string>::async([]()
-                                               {
+            return Promise<void>::async([]()
+                                        {
             try {
-                rust::String status_rs = bark_cxx::start_exit_for_entire_wallet();
-                return std::string(status_rs.data(), status_rs.length());
+                bark_cxx::start_exit_for_entire_wallet();
             } catch (const rust::Error &e) {
                 throw std::runtime_error(e.what());
             } });

--- a/react-native-nitro-ark/cpp/generated/ark_cxx.h
+++ b/react-native-nitro-ark/cpp/generated/ark_cxx.h
@@ -1009,7 +1009,7 @@ void load_wallet(::rust::Str datadir, ::bark_cxx::CreateOpts opts);
 
 ::rust::String start_exit_for_vtxos(::rust::Vec<::rust::String> vtxo_ids);
 
-::rust::String start_exit_for_entire_wallet();
+void start_exit_for_entire_wallet();
 
 ::rust::String exit_progress_once();
 } // namespace bark_cxx

--- a/react-native-nitro-ark/example/package.json
+++ b/react-native-nitro-ark/example/package.json
@@ -14,8 +14,8 @@
     "@dr.pogodin/react-native-fs": "^2.32.1",
     "@react-native-async-storage/async-storage": "^2.1.2",
     "react": "19.0.0",
-    "react-native": "0.79.3",
-    "react-native-nitro-modules": "^0.26.2"
+    "react-native": "0.79.5",
+    "react-native-nitro-modules": "^0.26.4"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",
@@ -24,11 +24,11 @@
     "@react-native-community/cli": "18.0.0",
     "@react-native-community/cli-platform-android": "18.0.0",
     "@react-native-community/cli-platform-ios": "18.0.0",
-    "@react-native/babel-preset": "0.79.3",
-    "@react-native/metro-config": "0.79.3",
-    "@react-native/typescript-config": "0.79.3",
+    "@react-native/babel-preset": "0.79.5",
+    "@react-native/metro-config": "0.79.5",
+    "@react-native/typescript-config": "0.79.5",
     "@types/react": "^19.0.10",
-    "react-native-builder-bob": "^0.40.12"
+    "react-native-builder-bob": "^0.40.13"
   },
   "engines": {
     "node": ">=18"

--- a/react-native-nitro-ark/nitrogen/generated/ios/NitroArk-Swift-Cxx-Umbrella.hpp
+++ b/react-native-nitro-ark/nitrogen/generated/ios/NitroArk-Swift-Cxx-Umbrella.hpp
@@ -18,7 +18,7 @@
 
 // Common C++ types used in Swift
 #include <NitroModules/ArrayBufferHolder.hpp>
-#include <NitroModules/AnyMapHolder.hpp>
+#include <NitroModules/AnyMapUtils.hpp>
 #include <NitroModules/RuntimeError.hpp>
 #include <NitroModules/DateToChronoDate.hpp>
 

--- a/react-native-nitro-ark/nitrogen/generated/shared/c++/HybridNitroArkSpec.cpp
+++ b/react-native-nitro-ark/nitrogen/generated/shared/c++/HybridNitroArkSpec.cpp
@@ -44,7 +44,7 @@ namespace margelo::nitro::nitroark {
       prototype.registerHybridMethod("offboardSpecific", &HybridNitroArkSpec::offboardSpecific);
       prototype.registerHybridMethod("offboardAll", &HybridNitroArkSpec::offboardAll);
       prototype.registerHybridMethod("exitStartSpecific", &HybridNitroArkSpec::exitStartSpecific);
-      prototype.registerHybridMethod("exitStartAll", &HybridNitroArkSpec::exitStartAll);
+      prototype.registerHybridMethod("startExitForEntireWallet", &HybridNitroArkSpec::startExitForEntireWallet);
       prototype.registerHybridMethod("exitProgressOnce", &HybridNitroArkSpec::exitProgressOnce);
     });
   }

--- a/react-native-nitro-ark/nitrogen/generated/shared/c++/HybridNitroArkSpec.hpp
+++ b/react-native-nitro-ark/nitrogen/generated/shared/c++/HybridNitroArkSpec.hpp
@@ -104,7 +104,7 @@ namespace margelo::nitro::nitroark {
       virtual std::shared_ptr<Promise<std::string>> offboardSpecific(const std::vector<std::string>& vtxoIds, const std::string& destinationAddress) = 0;
       virtual std::shared_ptr<Promise<std::string>> offboardAll(const std::string& destinationAddress) = 0;
       virtual std::shared_ptr<Promise<std::string>> exitStartSpecific(const std::vector<std::string>& vtxoIds) = 0;
-      virtual std::shared_ptr<Promise<std::string>> exitStartAll() = 0;
+      virtual std::shared_ptr<Promise<void>> startExitForEntireWallet() = 0;
       virtual std::shared_ptr<Promise<std::string>> exitProgressOnce() = 0;
 
     protected:

--- a/react-native-nitro-ark/package.json
+++ b/react-native-nitro-ark/package.json
@@ -7,6 +7,7 @@
   "module": "./lib/module/index.js",
   "exports": {
     ".": {
+      "source": "./src/index.tsx",
       "types": "./lib/typescript/src/index.d.ts",
       "default": "./lib/module/index.js"
     },
@@ -76,12 +77,12 @@
     "eslint-config-prettier": "^10.1.1",
     "eslint-plugin-prettier": "^5.2.3",
     "jest": "^29.7.0",
-    "nitro-codegen": "^0.26.2",
+    "nitro-codegen": "^0.26.4",
     "prettier": "^3.0.3",
     "react": "19.0.0",
-    "react-native": "0.79.3",
-    "react-native-builder-bob": "^0.40.12",
-    "react-native-nitro-modules": "^0.26.2",
+    "react-native": "0.79.5",
+    "react-native-builder-bob": "^0.40.13",
+    "react-native-nitro-modules": "^0.26.4",
     "release-it": "^17.10.0",
     "turbo": "^1.10.7",
     "typescript": "^5.2.2"
@@ -168,6 +169,6 @@
   "create-react-native-library": {
     "languages": "kotlin-swift",
     "type": "nitro-module",
-    "version": "0.49.0"
+    "version": "0.52.0"
   }
 }

--- a/react-native-nitro-ark/src/NitroArk.nitro.ts
+++ b/react-native-nitro-ark/src/NitroArk.nitro.ts
@@ -143,6 +143,6 @@ export interface NitroArk extends HybridObject<{ ios: 'c++'; android: 'c++' }> {
   ): Promise<string>; // Returns JSON result
   offboardAll(destinationAddress: string): Promise<string>; // Returns JSON result
   exitStartSpecific(vtxoIds: string[]): Promise<string>;
-  exitStartAll(): Promise<string>;
+  startExitForEntireWallet(): Promise<void>;
   exitProgressOnce(): Promise<string>;
 }

--- a/react-native-nitro-ark/src/index.tsx
+++ b/react-native-nitro-ark/src/index.tsx
@@ -331,10 +331,10 @@ export function startExitForVtxos(vtxoIds: string[]): Promise<string> {
 
 /**
  * Starts the exit process for all VTXOs in the wallet.
- * @returns A promise resolving to a JSON status string.
+ * @returns A promise that resolves or rejects.
  */
-export function startExitForEntireWallet(): Promise<string> {
-  return NitroArkHybridObject.exitStartAll();
+export function startExitForEntireWallet(): Promise<void> {
+  return NitroArkHybridObject.startExitForEntireWallet();
 }
 
 /**

--- a/react-native-nitro-ark/yarn.lock
+++ b/react-native-nitro-ark/yarn.lock
@@ -2715,26 +2715,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@react-native/assets-registry@npm:0.79.3":
-  version: 0.79.3
-  resolution: "@react-native/assets-registry@npm:0.79.3"
-  checksum: a21674f2dcadaf2e759b564dbf5346a11d593eccd09de5d4e52cd3bf27acf12e84300116757dcae7244e4987a167e580f4774b7f7a2dec6d5dfec8992cb46871
+"@react-native/assets-registry@npm:0.79.5":
+  version: 0.79.5
+  resolution: "@react-native/assets-registry@npm:0.79.5"
+  checksum: fbf1c4ca18f2d16ce7eb2f321032f4923aacabde014e1318a2b0b76711eb7d4cb13afccef1018f10d3b4cfb12077542c3ac05a20cff01c199de49e24aed67a62
   languageName: node
   linkType: hard
 
-"@react-native/babel-plugin-codegen@npm:0.79.3":
-  version: 0.79.3
-  resolution: "@react-native/babel-plugin-codegen@npm:0.79.3"
+"@react-native/babel-plugin-codegen@npm:0.79.5":
+  version: 0.79.5
+  resolution: "@react-native/babel-plugin-codegen@npm:0.79.5"
   dependencies:
     "@babel/traverse": ^7.25.3
-    "@react-native/codegen": 0.79.3
-  checksum: 4ae44062424e53450968aaa8dbce070ecb8bb6402c75af75127616f76b98d8ffbf43e644fb2f8449582e9be1f92ff1e20bcb89798bcfe9daaae8b8ccc85477d5
+    "@react-native/codegen": 0.79.5
+  checksum: 43a681cf480aead43131baa53ec3c28d24e796e120038b4264a524bbb36d76017a010964e70562a9bc965b23c5ae64dfd5b351d965b18bb3a9761b178153332e
   languageName: node
   linkType: hard
 
-"@react-native/babel-preset@npm:0.79.3":
-  version: 0.79.3
-  resolution: "@react-native/babel-preset@npm:0.79.3"
+"@react-native/babel-preset@npm:0.79.5":
+  version: 0.79.5
+  resolution: "@react-native/babel-preset@npm:0.79.5"
   dependencies:
     "@babel/core": ^7.25.2
     "@babel/plugin-proposal-export-default-from": ^7.24.7
@@ -2777,19 +2777,19 @@ __metadata:
     "@babel/plugin-transform-typescript": ^7.25.2
     "@babel/plugin-transform-unicode-regex": ^7.24.7
     "@babel/template": ^7.25.0
-    "@react-native/babel-plugin-codegen": 0.79.3
+    "@react-native/babel-plugin-codegen": 0.79.5
     babel-plugin-syntax-hermes-parser: 0.25.1
     babel-plugin-transform-flow-enums: ^0.0.2
     react-refresh: ^0.14.0
   peerDependencies:
     "@babel/core": "*"
-  checksum: d42b8bced37a0c9bbfeef90ea699b5c8a3fc22392f8651c88801189384c2e45a1212c8a417d05830bc135de6ce7faf9e6ad8d190bb5b0e41587c4f0437f226ac
+  checksum: de7e57ed4ccfc62deec2aac2ffab0257b620c8af34ffc4d0fab15a074383800f226f7f95b69ae4117305240c7dba1ec2fc61083dcc21459972eb2712adf70fbc
   languageName: node
   linkType: hard
 
-"@react-native/codegen@npm:0.79.3":
-  version: 0.79.3
-  resolution: "@react-native/codegen@npm:0.79.3"
+"@react-native/codegen@npm:0.79.5":
+  version: 0.79.5
+  resolution: "@react-native/codegen@npm:0.79.5"
   dependencies:
     glob: ^7.1.1
     hermes-parser: 0.25.1
@@ -2798,15 +2798,15 @@ __metadata:
     yargs: ^17.6.2
   peerDependencies:
     "@babel/core": "*"
-  checksum: 26e3a24c47bf359e3f4ee0ac08eeca4086d0b4d0a2051e0e784e97f862f5566a3601f2cd006412c7f76614b6f1a51e2204dff062593992200973f4a94b03d432
+  checksum: 2254bada67ebd4f88c6fff5568a33588062deca1f53f5a371577618bd8fd0d0ab813c4c44f226e54bef25fbf2f8784e7f702b76cd617b39baab24d138346c9e3
   languageName: node
   linkType: hard
 
-"@react-native/community-cli-plugin@npm:0.79.3":
-  version: 0.79.3
-  resolution: "@react-native/community-cli-plugin@npm:0.79.3"
+"@react-native/community-cli-plugin@npm:0.79.5":
+  version: 0.79.5
+  resolution: "@react-native/community-cli-plugin@npm:0.79.5"
   dependencies:
-    "@react-native/dev-middleware": 0.79.3
+    "@react-native/dev-middleware": 0.79.5
     chalk: ^4.0.0
     debug: ^2.2.0
     invariant: ^2.2.4
@@ -2819,23 +2819,23 @@ __metadata:
   peerDependenciesMeta:
     "@react-native-community/cli":
       optional: true
-  checksum: 266c9a6895e25600e974349b9aa05136fa9f667c6fd6a16a228620044c387c7330e38bd56849b0e51c7ad0142bf91488ccc87b077bcf0e01e8b8e25ca2677104
+  checksum: 019fc2e3328063e0619dc8ebc511ac2285b4aa25038fd9ee9ff2e3674e039c9dcef5e2f6dc233b64d635a1e662681107c5512c8982d1b6663f3728e66d3b582e
   languageName: node
   linkType: hard
 
-"@react-native/debugger-frontend@npm:0.79.3":
-  version: 0.79.3
-  resolution: "@react-native/debugger-frontend@npm:0.79.3"
-  checksum: 36cdf2203ab1333ec61915cab0e3bfb67f537fa960757508b2d239a044fa1f9a8786644727a0d80928bff434cde55a66632b797e75c8a46d5ee24ba6252c3e35
+"@react-native/debugger-frontend@npm:0.79.5":
+  version: 0.79.5
+  resolution: "@react-native/debugger-frontend@npm:0.79.5"
+  checksum: 5f468a06ec4916fed8d4d865fe05c6fa0ba5ade7c8870bdede836f4b2210fd07974c6774f07b71098b50c625a45b141df7333aad174e43d8c607d64ff065d6e1
   languageName: node
   linkType: hard
 
-"@react-native/dev-middleware@npm:0.79.3":
-  version: 0.79.3
-  resolution: "@react-native/dev-middleware@npm:0.79.3"
+"@react-native/dev-middleware@npm:0.79.5":
+  version: 0.79.5
+  resolution: "@react-native/dev-middleware@npm:0.79.5"
   dependencies:
     "@isaacs/ttlcache": ^1.4.1
-    "@react-native/debugger-frontend": 0.79.3
+    "@react-native/debugger-frontend": 0.79.5
     chrome-launcher: ^0.15.2
     chromium-edge-launcher: ^0.2.0
     connect: ^3.6.5
@@ -2845,7 +2845,7 @@ __metadata:
     open: ^7.0.3
     serve-static: ^1.16.2
     ws: ^6.2.3
-  checksum: 69349ea8253837d46c9fa59d228a4a3f99acf2016fd7ce093a454fe6ec06d6b567a8910b2e2dcfa6a06e012a02b9fb885708fbb56ddf4e79b964122b6a8156d2
+  checksum: 0d2bd347060021287a3b47f37f7f942cda37be7cd58b51fb0aaa5ab3fe1ecc1359adc7cc845c70f301ad9a87731eb3cf91a66b09c15519393013378f16285c95
   languageName: node
   linkType: hard
 
@@ -2879,63 +2879,63 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@react-native/gradle-plugin@npm:0.79.3":
-  version: 0.79.3
-  resolution: "@react-native/gradle-plugin@npm:0.79.3"
-  checksum: 7eca88c207525109a435f39587c6d11f5546b7767df2fcc56e890938280a94604c82598ae2d67e95564533885cabfac7313518fb0b51146e9028e087bd1fd80d
+"@react-native/gradle-plugin@npm:0.79.5":
+  version: 0.79.5
+  resolution: "@react-native/gradle-plugin@npm:0.79.5"
+  checksum: f459ec6af3f82047af87861f6024014bc7d01c92ba458980a5478326e3286ecbdb7713c10497525bd0253da2d678ffbb8c5b720f3099716844ae534c10cc5e3d
   languageName: node
   linkType: hard
 
-"@react-native/js-polyfills@npm:0.79.3":
-  version: 0.79.3
-  resolution: "@react-native/js-polyfills@npm:0.79.3"
-  checksum: 9b2ade205b801916faf8b032193bcc70792480676416ce99fe22df40ca7b6c4ac95b226be47230979954b5571ed6afc815f151da6dc0c4f614ef931df1f118c7
+"@react-native/js-polyfills@npm:0.79.5":
+  version: 0.79.5
+  resolution: "@react-native/js-polyfills@npm:0.79.5"
+  checksum: a51a289ee7147c968e3626b43e5602ecf2c8b1f00c551ba5c8db9fc67fb26ca88cdf1718eca0a1e67281f900897b5fb490367ed9ab10361a1005e1d5ba3c2e34
   languageName: node
   linkType: hard
 
-"@react-native/metro-babel-transformer@npm:0.79.3":
-  version: 0.79.3
-  resolution: "@react-native/metro-babel-transformer@npm:0.79.3"
+"@react-native/metro-babel-transformer@npm:0.79.5":
+  version: 0.79.5
+  resolution: "@react-native/metro-babel-transformer@npm:0.79.5"
   dependencies:
     "@babel/core": ^7.25.2
-    "@react-native/babel-preset": 0.79.3
+    "@react-native/babel-preset": 0.79.5
     hermes-parser: 0.25.1
     nullthrows: ^1.1.1
   peerDependencies:
     "@babel/core": "*"
-  checksum: 493972ad2299d2f69787e2918334f43f371809098bec2a283c1a705b75ee0765a2d1869d4b62594da667ceefdb8fd91ac873c9308619e415d8cfe0739949ea69
+  checksum: 4f31dd4f094b2fe4ee44afb8c6b59d0c15d02b9c74b53e61f691f002cef34aacda52a60d07d3f84f069d6bdf4e1d5056c6b6c74400914544c7cd543b8dcba8cf
   languageName: node
   linkType: hard
 
-"@react-native/metro-config@npm:0.79.3":
-  version: 0.79.3
-  resolution: "@react-native/metro-config@npm:0.79.3"
+"@react-native/metro-config@npm:0.79.5":
+  version: 0.79.5
+  resolution: "@react-native/metro-config@npm:0.79.5"
   dependencies:
-    "@react-native/js-polyfills": 0.79.3
-    "@react-native/metro-babel-transformer": 0.79.3
+    "@react-native/js-polyfills": 0.79.5
+    "@react-native/metro-babel-transformer": 0.79.5
     metro-config: ^0.82.0
     metro-runtime: ^0.82.0
-  checksum: 76feddea598998e1e3618fa62a05ee614b1d886f6552a05d040eee81f05d5c99a8f12364f2db7f6ef38967c2459ccb6dc112b4e5f84921137e6fc7167e6b5277
+  checksum: 30159ee8be9488dad6e83c5b06056e46bbff689bd1374783c95c243ef8acca4718a89515b088ce5f693d0e344b28094faac3a4bb4126973ecd3974a4e5ed9cbb
   languageName: node
   linkType: hard
 
-"@react-native/normalize-colors@npm:0.79.3":
-  version: 0.79.3
-  resolution: "@react-native/normalize-colors@npm:0.79.3"
-  checksum: 2e37dc1549e51eaa2c51a216ca011b0b0c9af1d3d5d960bb1204fd3200f9ee1f3d39d1e6e17d429777a4ab833cadac056a6f6f80e48a11800894a3ce6f5734ab
+"@react-native/normalize-colors@npm:0.79.5":
+  version: 0.79.5
+  resolution: "@react-native/normalize-colors@npm:0.79.5"
+  checksum: 0c62e8e4e2473e669f87e425e1ccf49471c00b88606a626c0addb9817f5a782b3115fb98a91b36f3bf4536fae8585fbf17a988e59ccc851f79999008cd64a4e4
   languageName: node
   linkType: hard
 
-"@react-native/typescript-config@npm:0.79.3":
-  version: 0.79.3
-  resolution: "@react-native/typescript-config@npm:0.79.3"
-  checksum: fdb57a622f4252b5ad81a09d11d24803988800a2bf189719f6c9b4f434aa99def49a1cbe04b572832ad8401c10613b655cc6a824cba42354212d0910a39c6a04
+"@react-native/typescript-config@npm:0.79.5":
+  version: 0.79.5
+  resolution: "@react-native/typescript-config@npm:0.79.5"
+  checksum: 5d97999236be9af8911bedf9812d808385d618ffd3f45aba63fe01507d4c0da05b66d7c98898190ec8797971e8c8b3ad35c526054104534b11734b3b9a28d41c
   languageName: node
   linkType: hard
 
-"@react-native/virtualized-lists@npm:0.79.3":
-  version: 0.79.3
-  resolution: "@react-native/virtualized-lists@npm:0.79.3"
+"@react-native/virtualized-lists@npm:0.79.5":
+  version: 0.79.5
+  resolution: "@react-native/virtualized-lists@npm:0.79.5"
   dependencies:
     invariant: ^2.2.4
     nullthrows: ^1.1.1
@@ -2946,7 +2946,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 24b2f52275c8a4a5638821cd0ff894bee57dad2687e3cfaebde71c79bd2b0ca6d72218f15b51741d45eea6d04d8f19ba0f3658d4daed04824f1516fc4ddfb64f
+  checksum: edde6d639e65ec4b1ee2477e2f1ae7c5f72769d75dcf8cb265e0be5495c143e631221a65dbf8e3f472ab396144605269b3e1e7a88137f56259b2de680f271189
   languageName: node
   linkType: hard
 
@@ -9221,18 +9221,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nitro-codegen@npm:^0.26.2":
-  version: 0.26.2
-  resolution: "nitro-codegen@npm:0.26.2"
+"nitro-codegen@npm:^0.26.4":
+  version: 0.26.4
+  resolution: "nitro-codegen@npm:0.26.4"
   dependencies:
     chalk: ^5.3.0
-    react-native-nitro-modules: ^0.26.2
+    react-native-nitro-modules: ^0.26.4
     ts-morph: ^25.0.0
     yargs: ^17.7.2
-    zod: ^3.23.8
+    zod: ^4.0.5
   bin:
     nitro-codegen: lib/index.js
-  checksum: 36159ef4d078114dd7a7e1b25959a9dfd3e77cd690894b453a3d36bc45f5e0648c1e21b937008865ab3e58bf594e4f1e523ce87c3f7e8cf1d1c5b5392c64c082
+  checksum: a059c6fa2ada4922d3aba6875f8e19753b1bbe4be610aeecce910c384b623a2428f3270f6f182afe7b6e8ee141aded35aa7b1555b9847f60cfcaccbd97c9b3b4
   languageName: node
   linkType: hard
 
@@ -10167,9 +10167,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-builder-bob@npm:^0.40.12":
-  version: 0.40.12
-  resolution: "react-native-builder-bob@npm:0.40.12"
+"react-native-builder-bob@npm:^0.40.13":
+  version: 0.40.13
+  resolution: "react-native-builder-bob@npm:0.40.13"
   dependencies:
     "@babel/core": ^7.25.2
     "@babel/plugin-transform-flow-strip-types": ^7.26.5
@@ -10195,7 +10195,7 @@ __metadata:
     yargs: ^17.5.1
   bin:
     bob: bin/bob
-  checksum: 90869f3835597ba2b6a0cf6f5922120693d33c1b89da16f798731b3c4b99697f652948581f559c159ba380ee1f7ccd09cb6ce45b8b2749f1987c569ed3116661
+  checksum: 3140749ce4c2b4362502b2074ef2a6de92e03ab1a49bdbfc8058fbea0335a000d0554d012d9ce857b18bc395a2d6796c011d922725089e4688d6760f0b56b519
   languageName: node
   linkType: hard
 
@@ -10221,14 +10221,14 @@ __metadata:
     "@react-native-community/cli": 18.0.0
     "@react-native-community/cli-platform-android": 18.0.0
     "@react-native-community/cli-platform-ios": 18.0.0
-    "@react-native/babel-preset": 0.79.3
-    "@react-native/metro-config": 0.79.3
-    "@react-native/typescript-config": 0.79.3
+    "@react-native/babel-preset": 0.79.5
+    "@react-native/metro-config": 0.79.5
+    "@react-native/typescript-config": 0.79.5
     "@types/react": ^19.0.10
     react: 19.0.0
-    react-native: 0.79.3
-    react-native-builder-bob: ^0.40.12
-    react-native-nitro-modules: ^0.26.2
+    react-native: 0.79.5
+    react-native-builder-bob: ^0.40.13
+    react-native-nitro-modules: ^0.26.4
   languageName: unknown
   linkType: soft
 
@@ -10251,12 +10251,12 @@ __metadata:
     eslint-config-prettier: ^10.1.1
     eslint-plugin-prettier: ^5.2.3
     jest: ^29.7.0
-    nitro-codegen: ^0.26.2
+    nitro-codegen: ^0.26.4
     prettier: ^3.0.3
     react: 19.0.0
-    react-native: 0.79.3
-    react-native-builder-bob: ^0.40.12
-    react-native-nitro-modules: ^0.26.2
+    react-native: 0.79.5
+    react-native-builder-bob: ^0.40.13
+    react-native-nitro-modules: ^0.26.4
     release-it: ^17.10.0
     turbo: ^1.10.7
     typescript: ^5.2.2
@@ -10267,28 +10267,28 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"react-native-nitro-modules@npm:^0.26.2":
-  version: 0.26.2
-  resolution: "react-native-nitro-modules@npm:0.26.2"
+"react-native-nitro-modules@npm:^0.26.4":
+  version: 0.26.4
+  resolution: "react-native-nitro-modules@npm:0.26.4"
   peerDependencies:
     react: "*"
     react-native: "*"
-  checksum: 957b7dae77102f44d5a26d65b665193de510eb5cfefc0417ffdcd5b2357994122f6384296c3ed3d2ce51166769c66457d77c39e62ce6aafa37dcf55fee7f4b5a
+  checksum: 1851f7c19c8af6c7ceaac97d2c8f105826a167ca29e1189525bcb4c4c52902ba72fc51b52a3d4ff0dd1beb4cf74405435b1badac7552a71ef8fbb235503274ba
   languageName: node
   linkType: hard
 
-"react-native@npm:0.79.3":
-  version: 0.79.3
-  resolution: "react-native@npm:0.79.3"
+"react-native@npm:0.79.5":
+  version: 0.79.5
+  resolution: "react-native@npm:0.79.5"
   dependencies:
     "@jest/create-cache-key-function": ^29.7.0
-    "@react-native/assets-registry": 0.79.3
-    "@react-native/codegen": 0.79.3
-    "@react-native/community-cli-plugin": 0.79.3
-    "@react-native/gradle-plugin": 0.79.3
-    "@react-native/js-polyfills": 0.79.3
-    "@react-native/normalize-colors": 0.79.3
-    "@react-native/virtualized-lists": 0.79.3
+    "@react-native/assets-registry": 0.79.5
+    "@react-native/codegen": 0.79.5
+    "@react-native/community-cli-plugin": 0.79.5
+    "@react-native/gradle-plugin": 0.79.5
+    "@react-native/js-polyfills": 0.79.5
+    "@react-native/normalize-colors": 0.79.5
+    "@react-native/virtualized-lists": 0.79.5
     abort-controller: ^3.0.0
     anser: ^1.4.9
     ansi-regex: ^5.0.0
@@ -10325,7 +10325,7 @@ __metadata:
       optional: true
   bin:
     react-native: cli.js
-  checksum: 9af72e5bf936744a4f727fb2c0b5fca6986361f445125081f108f99a1dea1dc6050c44ed4c1b654fd14a5a554da18d748f4d462161f7ab5d4ea6658d8fccce5f
+  checksum: 6db9368ca97ad2b4b2326d63edcb4ac151d77ad564afb3cbf1ae5caf8f169fee02bc83cb2411fc8b3e42f9d1ef08b2ac937a4260f67187829bed310e5d431988
   languageName: node
   linkType: hard
 
@@ -12469,9 +12469,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"zod@npm:^3.23.8":
-  version: 3.24.2
-  resolution: "zod@npm:3.24.2"
-  checksum: c02455c09678c5055c636d64f9fcda2424fea0aa46ac7d9681e7f41990bc55f488bcd84b9d7cfef0f6e906f51f55b245239d92a9f726248aa74c5b84edf00c2d
+"zod@npm:^4.0.5":
+  version: 4.0.5
+  resolution: "zod@npm:4.0.5"
+  checksum: d1e35c6737ac448e2115e5f3bfa4d71e398f4f4c95243fd4128dca74f7df40163337a26c812bc365ea95e27206787ab57bd4d682c8e8b8af2ed298eff1e7d8ba
   languageName: node
   linkType: hard


### PR DESCRIPTION
- Bump nitro-modules to latest version.
- Bump nitrogen to latest version.
- Bump other dependencies builder-bob dependencies
- Return type of `start_exit_for_entire_wallet` is now `void` instead of a `string`.