### PR TITLE
Add new methods that are related to refreshing vtxos

### DIFF
--- a/react-native-nitro-ark/cpp/generated/ark_cxx.h
+++ b/react-native-nitro-ark/cpp/generated/ark_cxx.h
@@ -820,8 +820,10 @@ namespace bark_cxx {
 struct BarkVtxo final {
   ::std::uint64_t amount CXX_DEFAULT_VALUE(0);
   ::std::uint32_t expiry_height CXX_DEFAULT_VALUE(0);
+  ::rust::String asp_pubkey;
   ::std::uint16_t exit_delta CXX_DEFAULT_VALUE(0);
   ::rust::String anchor_point;
+  ::rust::String point;
 
   using IsRelocatable = ::std::true_type;
 };
@@ -1028,9 +1030,13 @@ bool verify_message(::rust::Str message, ::rust::Str signature, ::rust::Str publ
 
 ::rust::Vec<::bark_cxx::BarkVtxo> get_vtxos();
 
+::rust::Vec<::bark_cxx::BarkVtxo> get_expiring_vtxos(::std::uint32_t threshold);
+
 ::rust::String bolt11_invoice(::std::uint64_t amount_msat);
 
 void maintenance();
+
+void maintenance_refresh();
 
 void sync();
 

--- a/react-native-nitro-ark/example/ios/Podfile.lock
+++ b/react-native-nitro-ark/example/ios/Podfile.lock
@@ -32,7 +32,7 @@ PODS:
   - hermes-engine (0.79.5):
     - hermes-engine/Pre-built (= 0.79.5)
   - hermes-engine/Pre-built (0.79.5)
-  - NitroArk (0.0.47):
+  - NitroArk (0.0.48):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -57,7 +57,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - NitroModules (0.26.4):
+  - NitroModules (0.28.0):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1997,8 +1997,8 @@ SPEC CHECKSUMS:
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
   glog: 5683914934d5b6e4240e497e0f4a3b42d1854183
   hermes-engine: f03b0e06d3882d71e67e45b073bb827da1a21aae
-  NitroArk: f4d624391dd9dc9201636bc8be92c87f37461e83
-  NitroModules: 763fe03c46a734a615e648ff2c77158cd26d8f89
+  NitroArk: 2be5f82533cddcd6aebc794092da38f5b8a9a6cf
+  NitroModules: 6f5dafb3e513b6b0766eea959ea3106948cafe45
   RCT-Folly: e78785aa9ba2ed998ea4151e314036f6c49e6d82
   RCTDeprecation: 5f638f65935e273753b1f31a365db6a8d6dc53b5
   RCTRequired: 8b46a520ea9071e2bc47d474aa9ca31b4a935bd8

--- a/react-native-nitro-ark/example/package.json
+++ b/react-native-nitro-ark/example/package.json
@@ -15,7 +15,7 @@
     "@react-native-async-storage/async-storage": "^2.1.2",
     "react": "19.0.0",
     "react-native": "0.79.5",
-    "react-native-nitro-modules": "^0.26.4"
+    "react-native-nitro-modules": "^0.28.0"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/react-native-nitro-ark/example/src/App.tsx
+++ b/react-native-nitro-ark/example/src/App.tsx
@@ -295,6 +295,14 @@ export default function ArkApp() {
     runOperation('maintenance', () => NitroArk.maintenance(), 'management');
   };
 
+  const handleMaintenanceRefresh = () => {
+    runOperation(
+      'maintenanceRefresh',
+      () => NitroArk.maintenanceRefresh(),
+      'management'
+    );
+  };
+
   const handleSync = () => {
     runOperation(
       'sync',
@@ -449,6 +457,18 @@ export default function ArkApp() {
       return;
     }
     runOperation('getVtxos', () => NitroArk.getVtxos(), 'walletInfo');
+  };
+
+  const handleGetExpiringVtxos = () => {
+    if (!mnemonic) {
+      setError((prev) => ({ ...prev, walletInfo: 'Mnemonic required' }));
+      return;
+    }
+    runOperation(
+      'getExpiringVtxos',
+      () => NitroArk.getExpiringVtxos(5000),
+      'walletInfo'
+    );
   };
 
   const handleSendOnchain = () => {
@@ -831,6 +851,10 @@ export default function ArkApp() {
             </View>
             {renderOperationButton('Persist Config', handlePersistConfig)}
             {renderOperationButton('Maintenance', handleMaintenance)}
+            {renderOperationButton(
+              'Maintenance Refresh',
+              handleMaintenanceRefresh
+            )}
             {renderOperationButton('Sync', handleSync)}
             {renderOperationButton('Onchain Sync', handleOnchainSync)}
             {renderOperationButton('Sync Exits', handleSyncExits)}
@@ -906,6 +930,10 @@ export default function ArkApp() {
             )}
             {renderOperationButton('Get Onchain UTXOs', handleGetOnchainUtxos)}
             {renderOperationButton('Get VTXOs', handleGetVtxos)}
+            {renderOperationButton(
+              'Get Expiring VTXOs',
+              handleGetExpiringVtxos
+            )}
           </View>
         </View>
 

--- a/react-native-nitro-ark/nitrogen/generated/shared/c++/BarkVtxo.hpp
+++ b/react-native-nitro-ark/nitrogen/generated/shared/c++/BarkVtxo.hpp
@@ -31,12 +31,14 @@ namespace margelo::nitro::nitroark {
   public:
     double amount     SWIFT_PRIVATE;
     double expiry_height     SWIFT_PRIVATE;
+    std::string asp_pubkey     SWIFT_PRIVATE;
     double exit_delta     SWIFT_PRIVATE;
     std::string anchor_point     SWIFT_PRIVATE;
+    std::string point     SWIFT_PRIVATE;
 
   public:
     BarkVtxo() = default;
-    explicit BarkVtxo(double amount, double expiry_height, double exit_delta, std::string anchor_point): amount(amount), expiry_height(expiry_height), exit_delta(exit_delta), anchor_point(anchor_point) {}
+    explicit BarkVtxo(double amount, double expiry_height, std::string asp_pubkey, double exit_delta, std::string anchor_point, std::string point): amount(amount), expiry_height(expiry_height), asp_pubkey(asp_pubkey), exit_delta(exit_delta), anchor_point(anchor_point), point(point) {}
   };
 
 } // namespace margelo::nitro::nitroark
@@ -53,16 +55,20 @@ namespace margelo::nitro {
       return BarkVtxo(
         JSIConverter<double>::fromJSI(runtime, obj.getProperty(runtime, "amount")),
         JSIConverter<double>::fromJSI(runtime, obj.getProperty(runtime, "expiry_height")),
+        JSIConverter<std::string>::fromJSI(runtime, obj.getProperty(runtime, "asp_pubkey")),
         JSIConverter<double>::fromJSI(runtime, obj.getProperty(runtime, "exit_delta")),
-        JSIConverter<std::string>::fromJSI(runtime, obj.getProperty(runtime, "anchor_point"))
+        JSIConverter<std::string>::fromJSI(runtime, obj.getProperty(runtime, "anchor_point")),
+        JSIConverter<std::string>::fromJSI(runtime, obj.getProperty(runtime, "point"))
       );
     }
     static inline jsi::Value toJSI(jsi::Runtime& runtime, const BarkVtxo& arg) {
       jsi::Object obj(runtime);
       obj.setProperty(runtime, "amount", JSIConverter<double>::toJSI(runtime, arg.amount));
       obj.setProperty(runtime, "expiry_height", JSIConverter<double>::toJSI(runtime, arg.expiry_height));
+      obj.setProperty(runtime, "asp_pubkey", JSIConverter<std::string>::toJSI(runtime, arg.asp_pubkey));
       obj.setProperty(runtime, "exit_delta", JSIConverter<double>::toJSI(runtime, arg.exit_delta));
       obj.setProperty(runtime, "anchor_point", JSIConverter<std::string>::toJSI(runtime, arg.anchor_point));
+      obj.setProperty(runtime, "point", JSIConverter<std::string>::toJSI(runtime, arg.point));
       return obj;
     }
     static inline bool canConvert(jsi::Runtime& runtime, const jsi::Value& value) {
@@ -72,8 +78,10 @@ namespace margelo::nitro {
       jsi::Object obj = value.getObject(runtime);
       if (!JSIConverter<double>::canConvert(runtime, obj.getProperty(runtime, "amount"))) return false;
       if (!JSIConverter<double>::canConvert(runtime, obj.getProperty(runtime, "expiry_height"))) return false;
+      if (!JSIConverter<std::string>::canConvert(runtime, obj.getProperty(runtime, "asp_pubkey"))) return false;
       if (!JSIConverter<double>::canConvert(runtime, obj.getProperty(runtime, "exit_delta"))) return false;
       if (!JSIConverter<std::string>::canConvert(runtime, obj.getProperty(runtime, "anchor_point"))) return false;
+      if (!JSIConverter<std::string>::canConvert(runtime, obj.getProperty(runtime, "point"))) return false;
       return true;
     }
   };

--- a/react-native-nitro-ark/nitrogen/generated/shared/c++/HybridNitroArkSpec.cpp
+++ b/react-native-nitro-ark/nitrogen/generated/shared/c++/HybridNitroArkSpec.cpp
@@ -21,6 +21,7 @@ namespace margelo::nitro::nitroark {
       prototype.registerHybridMethod("closeWallet", &HybridNitroArkSpec::closeWallet);
       prototype.registerHybridMethod("persistConfig", &HybridNitroArkSpec::persistConfig);
       prototype.registerHybridMethod("maintenance", &HybridNitroArkSpec::maintenance);
+      prototype.registerHybridMethod("maintenanceRefresh", &HybridNitroArkSpec::maintenanceRefresh);
       prototype.registerHybridMethod("sync", &HybridNitroArkSpec::sync);
       prototype.registerHybridMethod("syncExits", &HybridNitroArkSpec::syncExits);
       prototype.registerHybridMethod("syncRounds", &HybridNitroArkSpec::syncRounds);
@@ -32,6 +33,7 @@ namespace margelo::nitro::nitroark {
       prototype.registerHybridMethod("signMessage", &HybridNitroArkSpec::signMessage);
       prototype.registerHybridMethod("verifyMessage", &HybridNitroArkSpec::verifyMessage);
       prototype.registerHybridMethod("getVtxos", &HybridNitroArkSpec::getVtxos);
+      prototype.registerHybridMethod("getExpiringVtxos", &HybridNitroArkSpec::getExpiringVtxos);
       prototype.registerHybridMethod("onchainBalance", &HybridNitroArkSpec::onchainBalance);
       prototype.registerHybridMethod("onchainSync", &HybridNitroArkSpec::onchainSync);
       prototype.registerHybridMethod("onchainListUnspent", &HybridNitroArkSpec::onchainListUnspent);

--- a/react-native-nitro-ark/nitrogen/generated/shared/c++/HybridNitroArkSpec.hpp
+++ b/react-native-nitro-ark/nitrogen/generated/shared/c++/HybridNitroArkSpec.hpp
@@ -96,6 +96,7 @@ namespace margelo::nitro::nitroark {
       virtual std::shared_ptr<Promise<void>> closeWallet() = 0;
       virtual std::shared_ptr<Promise<void>> persistConfig(const BarkConfigOpts& opts) = 0;
       virtual std::shared_ptr<Promise<void>> maintenance() = 0;
+      virtual std::shared_ptr<Promise<void>> maintenanceRefresh() = 0;
       virtual std::shared_ptr<Promise<void>> sync() = 0;
       virtual std::shared_ptr<Promise<void>> syncExits() = 0;
       virtual std::shared_ptr<Promise<void>> syncRounds() = 0;
@@ -107,6 +108,7 @@ namespace margelo::nitro::nitroark {
       virtual std::shared_ptr<Promise<std::string>> signMessage(const std::string& message, double index) = 0;
       virtual std::shared_ptr<Promise<bool>> verifyMessage(const std::string& message, const std::string& signature, const std::string& publicKey) = 0;
       virtual std::shared_ptr<Promise<std::vector<BarkVtxo>>> getVtxos() = 0;
+      virtual std::shared_ptr<Promise<std::vector<BarkVtxo>>> getExpiringVtxos(double threshold) = 0;
       virtual std::shared_ptr<Promise<OnchainBalanceResult>> onchainBalance() = 0;
       virtual std::shared_ptr<Promise<void>> onchainSync() = 0;
       virtual std::shared_ptr<Promise<std::string>> onchainListUnspent() = 0;

--- a/react-native-nitro-ark/package.json
+++ b/react-native-nitro-ark/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-nitro-ark",
-  "version": "0.0.47",
+  "version": "0.0.48",
   "description": "Pure C++ Nitro Modules for Ark client",
   "source": "./src/index.tsx",
   "main": "./lib/module/index.js",
@@ -82,12 +82,12 @@
     "eslint-config-prettier": "^10.1.1",
     "eslint-plugin-prettier": "^5.2.3",
     "jest": "^29.7.0",
-    "nitro-codegen": "^0.26.4",
+    "nitro-codegen": "^0.28.0",
     "prettier": "^3.0.3",
     "react": "19.0.0",
     "react-native": "0.79.5",
     "react-native-builder-bob": "^0.40.13",
-    "react-native-nitro-modules": "^0.26.4",
+    "react-native-nitro-modules": "^0.28.0",
     "release-it": "^17.10.0",
     "turbo": "^1.10.7",
     "typescript": "^5.2.2"
@@ -95,7 +95,7 @@
   "peerDependencies": {
     "react": "*",
     "react-native": "*",
-    "react-native-nitro-modules": "^0.26.4"
+    "react-native-nitro-modules": "^0.28.0"
   },
   "workspaces": [
     "example"

--- a/react-native-nitro-ark/src/NitroArk.nitro.ts
+++ b/react-native-nitro-ark/src/NitroArk.nitro.ts
@@ -43,8 +43,10 @@ export interface BarkSendManyOutput {
 export interface BarkVtxo {
   amount: number; // u64
   expiry_height: number; // u32
+  asp_pubkey: string;
   exit_delta: number; // u16
   anchor_point: string;
+  point: string;
 }
 
 export type PaymentTypes = 'Bolt11' | 'Lnurl' | 'Arkoor' | 'Onchain';
@@ -115,6 +117,7 @@ export interface NitroArk extends HybridObject<{ ios: 'c++'; android: 'c++' }> {
   closeWallet(): Promise<void>;
   persistConfig(opts: BarkConfigOpts): Promise<void>;
   maintenance(): Promise<void>;
+  maintenanceRefresh(): Promise<void>;
   sync(): Promise<void>;
   syncExits(): Promise<void>;
   syncRounds(): Promise<void>;
@@ -131,7 +134,8 @@ export interface NitroArk extends HybridObject<{ ios: 'c++'; android: 'c++' }> {
     signature: string,
     publicKey: string
   ): Promise<boolean>;
-  getVtxos(): Promise<BarkVtxo[]>; // Returns JSON string
+  getVtxos(): Promise<BarkVtxo[]>;
+  getExpiringVtxos(threshold: number): Promise<BarkVtxo[]>;
 
   // --- Onchain Operations ---
   onchainBalance(): Promise<OnchainBalanceResult>;

--- a/react-native-nitro-ark/src/index.tsx
+++ b/react-native-nitro-ark/src/index.tsx
@@ -88,6 +88,14 @@ export function maintenance(): Promise<void> {
 }
 
 /**
+ * Refreshes vtxos that need to be refreshed.
+ * @returns A promise that resolves on success.
+ */
+export function maintenanceRefresh(): Promise<void> {
+  return NitroArkHybridObject.maintenanceRefresh();
+}
+
+/**
  * Synchronizes the wallet with the blockchain.
  * @returns A promise that resolves on success.
  */
@@ -188,6 +196,15 @@ export function getVtxos(): Promise<BarkVtxo[]> {
   return NitroArkHybridObject.getVtxos();
 }
 
+/**
+ * Gets the list of expiring VTXOs as a JSON Object of type BarkVtxo.
+ * @param no_sync If true, skips synchronization with the blockchain. Defaults to false.
+ * @returns A promise resolving BarkVtxo[] array.
+ */
+export function getExpiringVtxos(threshold: number): Promise<BarkVtxo[]> {
+  return NitroArkHybridObject.getExpiringVtxos(threshold);
+}
+
 // --- Onchain Operations ---
 
 /**
@@ -207,7 +224,7 @@ export function onchainSync(): Promise<void> {
 }
 
 /**
- * Gets the list of unspent onchain outputs as a JSON string for the loaded wallet.
+ * Gets the list of unspent onchain outputs as a JSON Object of type BarkVtxo.
  * @returns A promise resolving to the JSON string of unspent outputs.
  */
 export function onchainListUnspent(): Promise<string> {

--- a/react-native-nitro-ark/src/index.tsx
+++ b/react-native-nitro-ark/src/index.tsx
@@ -198,9 +198,9 @@ export function getVtxos(): Promise<BarkVtxo[]> {
 
 /**
  * Gets the list of expiring VTXOs as a JSON Object of type BarkVtxo.
- * @param no_sync If true, skips synchronization with the blockchain. Defaults to false.
+ * @param threshold The block height threshold to check for expiring VTXOs.
  * @returns A promise resolving BarkVtxo[] array.
- */
+
 export function getExpiringVtxos(threshold: number): Promise<BarkVtxo[]> {
   return NitroArkHybridObject.getExpiringVtxos(threshold);
 }

--- a/react-native-nitro-ark/yarn.lock
+++ b/react-native-nitro-ark/yarn.lock
@@ -9221,18 +9221,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nitro-codegen@npm:^0.26.4":
-  version: 0.26.4
-  resolution: "nitro-codegen@npm:0.26.4"
+"nitro-codegen@npm:^0.28.0":
+  version: 0.28.0
+  resolution: "nitro-codegen@npm:0.28.0"
   dependencies:
     chalk: ^5.3.0
-    react-native-nitro-modules: ^0.26.4
+    react-native-nitro-modules: ^0.28.0
     ts-morph: ^25.0.0
     yargs: ^17.7.2
     zod: ^4.0.5
   bin:
     nitro-codegen: lib/index.js
-  checksum: a059c6fa2ada4922d3aba6875f8e19753b1bbe4be610aeecce910c384b623a2428f3270f6f182afe7b6e8ee141aded35aa7b1555b9847f60cfcaccbd97c9b3b4
+  checksum: 8f7395e830f246c9348d7b6a152a11374aef8e28ca24b0df26d8acde8fe10bd8fdc6836a8b599838bb7723ebe4c9b00903e44acbfd5102ec3a939aa6aa9df287
   languageName: node
   linkType: hard
 
@@ -10228,7 +10228,7 @@ __metadata:
     react: 19.0.0
     react-native: 0.79.5
     react-native-builder-bob: ^0.40.13
-    react-native-nitro-modules: ^0.26.4
+    react-native-nitro-modules: ^0.28.0
   languageName: unknown
   linkType: soft
 
@@ -10251,29 +10251,29 @@ __metadata:
     eslint-config-prettier: ^10.1.1
     eslint-plugin-prettier: ^5.2.3
     jest: ^29.7.0
-    nitro-codegen: ^0.26.4
+    nitro-codegen: ^0.28.0
     prettier: ^3.0.3
     react: 19.0.0
     react-native: 0.79.5
     react-native-builder-bob: ^0.40.13
-    react-native-nitro-modules: ^0.26.4
+    react-native-nitro-modules: ^0.28.0
     release-it: ^17.10.0
     turbo: ^1.10.7
     typescript: ^5.2.2
   peerDependencies:
     react: "*"
     react-native: "*"
-    react-native-nitro-modules: ^0.26.4
+    react-native-nitro-modules: ^0.28.0
   languageName: unknown
   linkType: soft
 
-"react-native-nitro-modules@npm:^0.26.4":
-  version: 0.26.4
-  resolution: "react-native-nitro-modules@npm:0.26.4"
+"react-native-nitro-modules@npm:^0.28.0":
+  version: 0.28.0
+  resolution: "react-native-nitro-modules@npm:0.28.0"
   peerDependencies:
     react: "*"
     react-native: "*"
-  checksum: 1851f7c19c8af6c7ceaac97d2c8f105826a167ca29e1189525bcb4c4c52902ba72fc51b52a3d4ff0dd1beb4cf74405435b1badac7552a71ef8fbb235503274ba
+  checksum: 9cfca20c0257b4f7632407b40196e3ac88578d1a7f727093e1b08508a9dd640ed80f7be0de208f8c59e5553e58f8383772e6996c5941935c26433bb3539c75be
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- Bump nitro-modules to latest version.
- Add two new methods `get_expiring_vtxos` and `maintenance_refresh`.
- BarkVtxo type now returns additional information.
```
    pub struct BarkVtxo {
        amount: u64,
        expiry_height: u32,
        asp_pubkey: String,
        exit_delta: u16,
        anchor_point: String,
        point: String,
    }
```