### PR TITLE
Update Ark exit bindings for bark 0.2.1

### DIFF
--- a/bark-cpp/Cargo.lock
+++ b/bark-cpp/Cargo.lock
@@ -118,8 +118,8 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "ark-lib"
-version = "0.2.0"
-source = "git+https://gitlab.com/ark-bitcoin/bark.git?tag=bark-0.2.0#573da2c66f23aef1f1433a237f1a98df5cc1f0a9"
+version = "0.2.1"
+source = "git+https://gitlab.com/ark-bitcoin/bark.git?tag=bark-0.2.1#c788fb2d2916a1c487c672466afe52f9546a588d"
 dependencies = [
  "async-trait",
  "bark-bitcoin-ext",
@@ -173,8 +173,8 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "bark-bitcoin-ext"
-version = "0.2.0"
-source = "git+https://gitlab.com/ark-bitcoin/bark.git?tag=bark-0.2.0#573da2c66f23aef1f1433a237f1a98df5cc1f0a9"
+version = "0.2.1"
+source = "git+https://gitlab.com/ark-bitcoin/bark.git?tag=bark-0.2.1#c788fb2d2916a1c487c672466afe52f9546a588d"
 dependencies = [
  "bdk_bitcoind_rpc",
  "bdk_wallet",
@@ -212,8 +212,8 @@ dependencies = [
 
 [[package]]
 name = "bark-server-rpc"
-version = "0.2.0"
-source = "git+https://gitlab.com/ark-bitcoin/bark.git?tag=bark-0.2.0#573da2c66f23aef1f1433a237f1a98df5cc1f0a9"
+version = "0.2.1"
+source = "git+https://gitlab.com/ark-bitcoin/bark.git?tag=bark-0.2.1#c788fb2d2916a1c487c672466afe52f9546a588d"
 dependencies = [
  "ark-lib",
  "bitcoin",
@@ -230,8 +230,8 @@ dependencies = [
 
 [[package]]
 name = "bark-wallet"
-version = "0.2.0"
-source = "git+https://gitlab.com/ark-bitcoin/bark.git?tag=bark-0.2.0#573da2c66f23aef1f1433a237f1a98df5cc1f0a9"
+version = "0.2.1"
+source = "git+https://gitlab.com/ark-bitcoin/bark.git?tag=bark-0.2.1#c788fb2d2916a1c487c672466afe52f9546a588d"
 dependencies = [
  "anyhow",
  "ark-lib",
@@ -367,7 +367,7 @@ checksum = "32637268377fc7b10a8c6d51de3e7fba1ce5dd371a96e342b34e6078db558e7f"
 [[package]]
 name = "bip321"
 version = "0.1.0"
-source = "git+https://gitlab.com/ark-bitcoin/bark.git?tag=bark-0.2.0#573da2c66f23aef1f1433a237f1a98df5cc1f0a9"
+source = "git+https://gitlab.com/ark-bitcoin/bark.git?tag=bark-0.2.1#c788fb2d2916a1c487c672466afe52f9546a588d"
 dependencies = [
  "bitcoin",
  "lightning",

--- a/bark-cpp/Cargo.toml
+++ b/bark-cpp/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-bark-wallet = { git = "https://gitlab.com/ark-bitcoin/bark.git", tag = "bark-0.2.0", features = [
+bark-wallet = { git = "https://gitlab.com/ark-bitcoin/bark.git", tag = "bark-0.2.1", features = [
   "native",
   "tls-webpki-roots",
   "onchain-bdk",
@@ -12,7 +12,7 @@ bark-wallet = { git = "https://gitlab.com/ark-bitcoin/bark.git", tag = "bark-0.2
   "sqlite",
 ], default-features = false }
 
-bark-bitcoin-ext = { git = "https://gitlab.com/ark-bitcoin/bark.git", tag = "bark-0.2.0", default-features = false }
+bark-bitcoin-ext = { git = "https://gitlab.com/ark-bitcoin/bark.git", tag = "bark-0.2.1", default-features = false }
 bdk_wallet = { version = "3.0.0" }
 bdk_bitcoind_rpc = { version = "0.22.0" }
 chrono = { version = "0.4", features = ["serde"] }

--- a/bark-cpp/src/cxx.rs
+++ b/bark-cpp/src/cxx.rs
@@ -89,15 +89,11 @@ pub(crate) mod ffi {
         kind: String,
         has_confirmed_in: bool,
         confirmed_in: ExitBlockRefResult,
-        fee_rate_sat_per_kvb: u64,
-        total_fee_sat: u64,
     }
 
     pub struct ExitTxStatusResult {
         kind: String,
         txids: Vec<String>,
-        min_fee_rate_sat_per_kvb: u64,
-        min_fee_sat: u64,
         child_txid: String,
         has_origin: bool,
         origin: ExitTxOriginResult,
@@ -406,7 +402,6 @@ pub(crate) mod ffi {
         fn start_exit_for_entire_wallet() -> Result<()>;
         fn start_exit_for_vtxos(vtxo_ids: Vec<String>) -> Result<()>;
         fn sync_exit() -> Result<()>;
-        fn sync_no_progress() -> Result<()>;
         fn sync_pending_rounds() -> Result<()>;
         fn mailbox_keypair() -> Result<KeyPairResult>;
         fn mailbox_authorization(authorization_expiry: i64) -> Result<MailboxAuthorizationResult>;
@@ -937,8 +932,6 @@ fn empty_exit_tx_origin() -> ffi::ExitTxOriginResult {
         kind: String::new(),
         has_confirmed_in: false,
         confirmed_in: empty_exit_block_ref(),
-        fee_rate_sat_per_kvb: 0,
-        total_fee_sat: 0,
     }
 }
 
@@ -948,25 +941,16 @@ fn exit_tx_origin_to_ffi(origin: &bark::exit::ExitTxOrigin) -> ffi::ExitTxOrigin
             kind: "wallet".to_string(),
             has_confirmed_in: confirmed_in.is_some(),
             confirmed_in: confirmed_in.map_or_else(empty_exit_block_ref, exit_block_ref_to_ffi),
-            fee_rate_sat_per_kvb: 0,
-            total_fee_sat: 0,
         },
-        bark::exit::ExitTxOrigin::Mempool {
-            fee_rate,
-            total_fee,
-        } => ffi::ExitTxOriginResult {
+        bark::exit::ExitTxOrigin::Mempool => ffi::ExitTxOriginResult {
             kind: "mempool".to_string(),
             has_confirmed_in: false,
             confirmed_in: empty_exit_block_ref(),
-            fee_rate_sat_per_kvb: fee_rate.to_sat_per_kvb(),
-            total_fee_sat: total_fee.to_sat(),
         },
         bark::exit::ExitTxOrigin::Block { confirmed_in } => ffi::ExitTxOriginResult {
             kind: "block".to_string(),
             has_confirmed_in: true,
             confirmed_in: exit_block_ref_to_ffi(*confirmed_in),
-            fee_rate_sat_per_kvb: 0,
-            total_fee_sat: 0,
         },
     }
 }
@@ -975,8 +959,6 @@ fn empty_exit_tx_status() -> ffi::ExitTxStatusResult {
     ffi::ExitTxStatusResult {
         kind: String::new(),
         txids: Vec::new(),
-        min_fee_rate_sat_per_kvb: 0,
-        min_fee_sat: 0,
         child_txid: String::new(),
         has_origin: false,
         origin: empty_exit_tx_origin(),
@@ -1001,31 +983,13 @@ fn exit_tx_status_to_ffi(status: &bark::exit::ExitTxStatus) -> ffi::ExitTxStatus
                 ..empty_exit_tx_status()
             }
         }
-        bark::exit::ExitTxStatus::NeedsSignedPackage => ffi::ExitTxStatusResult {
-            kind: "needs-signed-package".to_string(),
+        bark::exit::ExitTxStatus::AwaitingCpfpBroadcast => ffi::ExitTxStatusResult {
+            kind: "awaiting-cpfp-broadcast".to_string(),
             ..empty_exit_tx_status()
         },
-        bark::exit::ExitTxStatus::NeedsReplacementPackage {
-            min_fee_rate,
-            min_fee,
-        } => ffi::ExitTxStatusResult {
-            kind: "needs-replacement-package".to_string(),
-            min_fee_rate_sat_per_kvb: min_fee_rate.to_sat_per_kvb(),
-            min_fee_sat: min_fee.to_sat(),
-            ..empty_exit_tx_status()
-        },
-        bark::exit::ExitTxStatus::NeedsBroadcasting { child_txid, origin } => {
+        bark::exit::ExitTxStatus::AwaitingConfirmation { child_txid, origin } => {
             ffi::ExitTxStatusResult {
-                kind: "needs-broadcasting".to_string(),
-                child_txid: child_txid.to_string(),
-                has_origin: true,
-                origin: exit_tx_origin_to_ffi(origin),
-                ..empty_exit_tx_status()
-            }
-        }
-        bark::exit::ExitTxStatus::BroadcastWithCpfp { child_txid, origin } => {
-            ffi::ExitTxStatusResult {
-                kind: "broadcast-with-cpfp".to_string(),
+                kind: "awaiting-confirmation".to_string(),
                 child_txid: child_txid.to_string(),
                 has_origin: true,
                 origin: exit_tx_origin_to_ffi(origin),
@@ -1540,10 +1504,6 @@ pub(crate) fn start_exit_for_entire_wallet() -> anyhow::Result<()> {
 
 pub(crate) fn start_exit_for_vtxos(vtxo_ids: Vec<String>) -> anyhow::Result<()> {
     TOKIO_RUNTIME.block_on(crate::start_exit_for_vtxos(vtxo_ids))
-}
-
-pub(crate) fn sync_no_progress() -> anyhow::Result<()> {
-    TOKIO_RUNTIME.block_on(crate::sync_no_progress())
 }
 
 pub(crate) fn sync_exit() -> anyhow::Result<()> {

--- a/bark-cpp/src/exit.rs
+++ b/bark-cpp/src/exit.rs
@@ -78,23 +78,9 @@ pub async fn sync_exit() -> anyhow::Result<()> {
     manager
         .with_context_async(|ctx| async {
             ctx.wallet
-                .sync_exits(&mut ctx.onchain_wallet)
+                .sync_exits()
                 .await
                 .context("Failed to sync exit")?;
-            Ok(())
-        })
-        .await
-}
-
-pub async fn sync_no_progress() -> anyhow::Result<()> {
-    let mut manager = GLOBAL_WALLET_MANAGER.lock().await;
-    manager
-        .with_context_async(|ctx| async {
-            ctx.wallet
-                .exit_mgr()
-                .sync_no_progress(&ctx.onchain_wallet)
-                .await
-                .context("Failed to sync exits without progress")?;
             Ok(())
         })
         .await
@@ -109,7 +95,7 @@ pub async fn progress_exits(
             let result = ctx
                 .wallet
                 .exit_mgr()
-                .progress_exits(ctx.wallet.as_ref(), &mut ctx.onchain_wallet, fee_rate)
+                .progress_exits_with_bdk(ctx.wallet.as_ref(), &mut ctx.onchain_wallet, fee_rate)
                 .await
                 .context("Failed to progress exits")?;
             Ok(result.unwrap_or_default())

--- a/bark-cpp/src/lib.rs
+++ b/bark-cpp/src/lib.rs
@@ -241,9 +241,7 @@ impl WalletManager {
             OnchainWallet::load_or_create(properties.network, mnemonic.to_seed(""), db.clone())
                 .await?;
         let lock_manager = Box::new(MemoryLockManager::new());
-        let wallet =
-            Wallet::open_with_onchain(&mnemonic, db.clone(), &onchain_wallet, config, lock_manager)
-                .await?;
+        let wallet = Wallet::open_with_exits(&mnemonic, db.clone(), config, lock_manager).await?;
 
         Ok((wallet, onchain_wallet))
     }

--- a/bark-cpp/src/onchain.rs
+++ b/bark-cpp/src/onchain.rs
@@ -1,4 +1,4 @@
-use bark::onchain::{ChainSync, Utxo};
+use bark::onchain::{ChainSync, GetAddress, Utxo};
 use bdk_wallet::bitcoin::{Address, Amount, FeeRate, Psbt, Transaction, Txid};
 
 use crate::GLOBAL_WALLET_MANAGER;

--- a/bark-cpp/src/utils.rs
+++ b/bark-cpp/src/utils.rs
@@ -182,16 +182,9 @@ pub(crate) async fn try_create_wallet(
         .context("failed to load or create onchain wallet")?;
     let lock_manager = Box::new(MemoryLockManager::new());
     debug!("Creating bark wallet with exit support");
-    match BarkWallet::create_with_exits(
-        &mnemonic,
-        net,
-        config,
-        db,
-        lock_manager,
-        false,
-    )
-    .await
-    .context("error creating wallet")
+    match BarkWallet::create_with_exits(&mnemonic, net, config, db, lock_manager, false)
+        .await
+        .context("error creating wallet")
     {
         Ok(_) => {
             info!("Created bark wallet successfully");

--- a/bark-cpp/src/utils.rs
+++ b/bark-cpp/src/utils.rs
@@ -177,18 +177,17 @@ pub(crate) async fn try_create_wallet(
     );
 
     debug!("Loading or creating onchain wallet");
-    let bdk_wallet = OnchainWallet::load_or_create(net, seed, db.clone())
+    OnchainWallet::load_or_create(net, seed, db.clone())
         .await
         .context("failed to load or create onchain wallet")?;
     let lock_manager = Box::new(MemoryLockManager::new());
-    debug!("Creating bark wallet with onchain backend");
-    match BarkWallet::create_with_onchain(
+    debug!("Creating bark wallet with exit support");
+    match BarkWallet::create_with_exits(
         &mnemonic,
         net,
         config,
         db,
         lock_manager,
-        &bdk_wallet,
         false,
     )
     .await

--- a/react-native-nitro-ark/cpp/NitroArk.hpp
+++ b/react-native-nitro-ark/cpp/NitroArk.hpp
@@ -48,12 +48,6 @@ inline ExitTxOriginResult convertRustExitTxOrigin(const bark_cxx::ExitTxOriginRe
   if (origin_rs.has_confirmed_in) {
     origin.confirmed_in = convertRustExitBlockRef(origin_rs.confirmed_in);
   }
-  if (origin_rs.fee_rate_sat_per_kvb != 0) {
-    origin.fee_rate_sat_per_kvb = static_cast<double>(origin_rs.fee_rate_sat_per_kvb);
-  }
-  if (origin_rs.total_fee_sat != 0) {
-    origin.total_fee_sat = static_cast<double>(origin_rs.total_fee_sat);
-  }
   return origin;
 }
 
@@ -67,12 +61,6 @@ inline ExitTxStatusResult convertRustExitTxStatus(const bark_cxx::ExitTxStatusRe
     for (const auto& txid : status_rs.txids) {
       status.txids->emplace_back(std::string(txid.data(), txid.length()));
     }
-  }
-  if (status_rs.min_fee_rate_sat_per_kvb != 0) {
-    status.min_fee_rate_sat_per_kvb = static_cast<double>(status_rs.min_fee_rate_sat_per_kvb);
-  }
-  if (status_rs.min_fee_sat != 0) {
-    status.min_fee_sat = static_cast<double>(status_rs.min_fee_sat);
   }
   if (status_rs.child_txid.length() != 0) {
     status.child_txid = std::string(status_rs.child_txid.data(), status_rs.child_txid.length());
@@ -474,16 +462,6 @@ public:
     return Promise<void>::async([]() {
       try {
         bark_cxx::sync_exit();
-      } catch (const rust::Error& e) {
-        throw std::runtime_error(e.what());
-      }
-    });
-  }
-
-  std::shared_ptr<Promise<void>> syncNoProgress() override {
-    return Promise<void>::async([]() {
-      try {
-        bark_cxx::sync_no_progress();
       } catch (const rust::Error& e) {
         throw std::runtime_error(e.what());
       }

--- a/react-native-nitro-ark/cpp/generated/ark_cxx.h
+++ b/react-native-nitro-ark/cpp/generated/ark_cxx.h
@@ -1113,8 +1113,6 @@ struct ExitTxOriginResult final {
   ::rust::String kind;
   bool has_confirmed_in CXX_DEFAULT_VALUE(false);
   ::bark_cxx::ExitBlockRefResult confirmed_in;
-  ::std::uint64_t fee_rate_sat_per_kvb CXX_DEFAULT_VALUE(0);
-  ::std::uint64_t total_fee_sat CXX_DEFAULT_VALUE(0);
 
   using IsRelocatable = ::std::true_type;
 };
@@ -1125,8 +1123,6 @@ struct ExitTxOriginResult final {
 struct ExitTxStatusResult final {
   ::rust::String kind;
   ::rust::Vec<::rust::String> txids;
-  ::std::uint64_t min_fee_rate_sat_per_kvb CXX_DEFAULT_VALUE(0);
-  ::std::uint64_t min_fee_sat CXX_DEFAULT_VALUE(0);
   ::rust::String child_txid;
   bool has_origin CXX_DEFAULT_VALUE(false);
   ::bark_cxx::ExitTxOriginResult origin;
@@ -1581,8 +1577,6 @@ void start_exit_for_entire_wallet();
 void start_exit_for_vtxos(::rust::Vec<::rust::String> vtxo_ids);
 
 void sync_exit();
-
-void sync_no_progress();
 
 void sync_pending_rounds();
 

--- a/react-native-nitro-ark/example/ios/Podfile.lock
+++ b/react-native-nitro-ark/example/ios/Podfile.lock
@@ -3,7 +3,7 @@ PODS:
   - hermes-engine (250829098.0.10):
     - hermes-engine/Pre-built (= 250829098.0.10)
   - hermes-engine/Pre-built (250829098.0.10)
-  - NitroArk (0.0.112):
+  - NitroArk (0.0.113):
     - hermes-engine
     - NitroModules
     - RCTRequired
@@ -2122,7 +2122,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   FBLazyVector: 24e62c765683b8d89006a88a2c8f5cf019f0074d
   hermes-engine: b9bc07e8e3778c44d446d1bfa9788de105e5c157
-  NitroArk: be47cbce0689323ab1fcc222d56455d6b8dd85f6
+  NitroArk: ce0d193fd7f39ef39f28f9d44b7a4e8f3194abeb
   NitroModules: ba9ddd723ffde85412ec774827d4a80ad9864b89
   RCTDeprecation: a4c521821fab57cbb125b36effe84d897d0dfa12
   RCTRequired: 9f3a7e5645d4bc3f551593de7550bb66ab6e42bc

--- a/react-native-nitro-ark/nitrogen/generated/shared/c++/ExitTxOriginResult.hpp
+++ b/react-native-nitro-ark/nitrogen/generated/shared/c++/ExitTxOriginResult.hpp
@@ -44,12 +44,10 @@ namespace margelo::nitro::nitroark {
   public:
     std::string kind     SWIFT_PRIVATE;
     std::optional<ExitBlockRefResult> confirmed_in     SWIFT_PRIVATE;
-    std::optional<double> fee_rate_sat_per_kvb     SWIFT_PRIVATE;
-    std::optional<double> total_fee_sat     SWIFT_PRIVATE;
 
   public:
     ExitTxOriginResult() = default;
-    explicit ExitTxOriginResult(std::string kind, std::optional<ExitBlockRefResult> confirmed_in, std::optional<double> fee_rate_sat_per_kvb, std::optional<double> total_fee_sat): kind(kind), confirmed_in(confirmed_in), fee_rate_sat_per_kvb(fee_rate_sat_per_kvb), total_fee_sat(total_fee_sat) {}
+    explicit ExitTxOriginResult(std::string kind, std::optional<ExitBlockRefResult> confirmed_in): kind(kind), confirmed_in(confirmed_in) {}
 
   public:
     friend bool operator==(const ExitTxOriginResult& lhs, const ExitTxOriginResult& rhs) = default;
@@ -66,17 +64,13 @@ namespace margelo::nitro {
       jsi::Object obj = arg.asObject(runtime);
       return margelo::nitro::nitroark::ExitTxOriginResult(
         JSIConverter<std::string>::fromJSI(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "kind"))),
-        JSIConverter<std::optional<margelo::nitro::nitroark::ExitBlockRefResult>>::fromJSI(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "confirmed_in"))),
-        JSIConverter<std::optional<double>>::fromJSI(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "fee_rate_sat_per_kvb"))),
-        JSIConverter<std::optional<double>>::fromJSI(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "total_fee_sat")))
+        JSIConverter<std::optional<margelo::nitro::nitroark::ExitBlockRefResult>>::fromJSI(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "confirmed_in")))
       );
     }
     static inline jsi::Value toJSI(jsi::Runtime& runtime, const margelo::nitro::nitroark::ExitTxOriginResult& arg) {
       jsi::Object obj(runtime);
       obj.setProperty(runtime, PropNameIDCache::get(runtime, "kind"), JSIConverter<std::string>::toJSI(runtime, arg.kind));
       obj.setProperty(runtime, PropNameIDCache::get(runtime, "confirmed_in"), JSIConverter<std::optional<margelo::nitro::nitroark::ExitBlockRefResult>>::toJSI(runtime, arg.confirmed_in));
-      obj.setProperty(runtime, PropNameIDCache::get(runtime, "fee_rate_sat_per_kvb"), JSIConverter<std::optional<double>>::toJSI(runtime, arg.fee_rate_sat_per_kvb));
-      obj.setProperty(runtime, PropNameIDCache::get(runtime, "total_fee_sat"), JSIConverter<std::optional<double>>::toJSI(runtime, arg.total_fee_sat));
       return obj;
     }
     static inline bool canConvert(jsi::Runtime& runtime, const jsi::Value& value) {
@@ -89,8 +83,6 @@ namespace margelo::nitro {
       }
       if (!JSIConverter<std::string>::canConvert(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "kind")))) return false;
       if (!JSIConverter<std::optional<margelo::nitro::nitroark::ExitBlockRefResult>>::canConvert(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "confirmed_in")))) return false;
-      if (!JSIConverter<std::optional<double>>::canConvert(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "fee_rate_sat_per_kvb")))) return false;
-      if (!JSIConverter<std::optional<double>>::canConvert(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "total_fee_sat")))) return false;
       return true;
     }
   };

--- a/react-native-nitro-ark/nitrogen/generated/shared/c++/ExitTxStatusResult.hpp
+++ b/react-native-nitro-ark/nitrogen/generated/shared/c++/ExitTxStatusResult.hpp
@@ -48,15 +48,13 @@ namespace margelo::nitro::nitroark {
   public:
     std::string kind     SWIFT_PRIVATE;
     std::optional<std::vector<std::string>> txids     SWIFT_PRIVATE;
-    std::optional<double> min_fee_rate_sat_per_kvb     SWIFT_PRIVATE;
-    std::optional<double> min_fee_sat     SWIFT_PRIVATE;
     std::optional<std::string> child_txid     SWIFT_PRIVATE;
     std::optional<ExitTxOriginResult> origin     SWIFT_PRIVATE;
     std::optional<ExitBlockRefResult> block     SWIFT_PRIVATE;
 
   public:
     ExitTxStatusResult() = default;
-    explicit ExitTxStatusResult(std::string kind, std::optional<std::vector<std::string>> txids, std::optional<double> min_fee_rate_sat_per_kvb, std::optional<double> min_fee_sat, std::optional<std::string> child_txid, std::optional<ExitTxOriginResult> origin, std::optional<ExitBlockRefResult> block): kind(kind), txids(txids), min_fee_rate_sat_per_kvb(min_fee_rate_sat_per_kvb), min_fee_sat(min_fee_sat), child_txid(child_txid), origin(origin), block(block) {}
+    explicit ExitTxStatusResult(std::string kind, std::optional<std::vector<std::string>> txids, std::optional<std::string> child_txid, std::optional<ExitTxOriginResult> origin, std::optional<ExitBlockRefResult> block): kind(kind), txids(txids), child_txid(child_txid), origin(origin), block(block) {}
 
   public:
     friend bool operator==(const ExitTxStatusResult& lhs, const ExitTxStatusResult& rhs) = default;
@@ -74,8 +72,6 @@ namespace margelo::nitro {
       return margelo::nitro::nitroark::ExitTxStatusResult(
         JSIConverter<std::string>::fromJSI(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "kind"))),
         JSIConverter<std::optional<std::vector<std::string>>>::fromJSI(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "txids"))),
-        JSIConverter<std::optional<double>>::fromJSI(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "min_fee_rate_sat_per_kvb"))),
-        JSIConverter<std::optional<double>>::fromJSI(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "min_fee_sat"))),
         JSIConverter<std::optional<std::string>>::fromJSI(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "child_txid"))),
         JSIConverter<std::optional<margelo::nitro::nitroark::ExitTxOriginResult>>::fromJSI(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "origin"))),
         JSIConverter<std::optional<margelo::nitro::nitroark::ExitBlockRefResult>>::fromJSI(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "block")))
@@ -85,8 +81,6 @@ namespace margelo::nitro {
       jsi::Object obj(runtime);
       obj.setProperty(runtime, PropNameIDCache::get(runtime, "kind"), JSIConverter<std::string>::toJSI(runtime, arg.kind));
       obj.setProperty(runtime, PropNameIDCache::get(runtime, "txids"), JSIConverter<std::optional<std::vector<std::string>>>::toJSI(runtime, arg.txids));
-      obj.setProperty(runtime, PropNameIDCache::get(runtime, "min_fee_rate_sat_per_kvb"), JSIConverter<std::optional<double>>::toJSI(runtime, arg.min_fee_rate_sat_per_kvb));
-      obj.setProperty(runtime, PropNameIDCache::get(runtime, "min_fee_sat"), JSIConverter<std::optional<double>>::toJSI(runtime, arg.min_fee_sat));
       obj.setProperty(runtime, PropNameIDCache::get(runtime, "child_txid"), JSIConverter<std::optional<std::string>>::toJSI(runtime, arg.child_txid));
       obj.setProperty(runtime, PropNameIDCache::get(runtime, "origin"), JSIConverter<std::optional<margelo::nitro::nitroark::ExitTxOriginResult>>::toJSI(runtime, arg.origin));
       obj.setProperty(runtime, PropNameIDCache::get(runtime, "block"), JSIConverter<std::optional<margelo::nitro::nitroark::ExitBlockRefResult>>::toJSI(runtime, arg.block));
@@ -102,8 +96,6 @@ namespace margelo::nitro {
       }
       if (!JSIConverter<std::string>::canConvert(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "kind")))) return false;
       if (!JSIConverter<std::optional<std::vector<std::string>>>::canConvert(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "txids")))) return false;
-      if (!JSIConverter<std::optional<double>>::canConvert(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "min_fee_rate_sat_per_kvb")))) return false;
-      if (!JSIConverter<std::optional<double>>::canConvert(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "min_fee_sat")))) return false;
       if (!JSIConverter<std::optional<std::string>>::canConvert(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "child_txid")))) return false;
       if (!JSIConverter<std::optional<margelo::nitro::nitroark::ExitTxOriginResult>>::canConvert(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "origin")))) return false;
       if (!JSIConverter<std::optional<margelo::nitro::nitroark::ExitBlockRefResult>>::canConvert(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "block")))) return false;

--- a/react-native-nitro-ark/nitrogen/generated/shared/c++/HybridNitroArkSpec.cpp
+++ b/react-native-nitro-ark/nitrogen/generated/shared/c++/HybridNitroArkSpec.cpp
@@ -30,7 +30,6 @@ namespace margelo::nitro::nitroark {
       prototype.registerHybridMethod("startExitForEntireWallet", &HybridNitroArkSpec::startExitForEntireWallet);
       prototype.registerHybridMethod("startExitForVtxos", &HybridNitroArkSpec::startExitForVtxos);
       prototype.registerHybridMethod("syncExit", &HybridNitroArkSpec::syncExit);
-      prototype.registerHybridMethod("syncNoProgress", &HybridNitroArkSpec::syncNoProgress);
       prototype.registerHybridMethod("progressExits", &HybridNitroArkSpec::progressExits);
       prototype.registerHybridMethod("getExitVtxos", &HybridNitroArkSpec::getExitVtxos);
       prototype.registerHybridMethod("listClaimable", &HybridNitroArkSpec::listClaimable);

--- a/react-native-nitro-ark/nitrogen/generated/shared/c++/HybridNitroArkSpec.hpp
+++ b/react-native-nitro-ark/nitrogen/generated/shared/c++/HybridNitroArkSpec.hpp
@@ -136,7 +136,6 @@ namespace margelo::nitro::nitroark {
       virtual std::shared_ptr<Promise<void>> startExitForEntireWallet() = 0;
       virtual std::shared_ptr<Promise<void>> startExitForVtxos(const std::vector<std::string>& vtxoIds) = 0;
       virtual std::shared_ptr<Promise<void>> syncExit() = 0;
-      virtual std::shared_ptr<Promise<void>> syncNoProgress() = 0;
       virtual std::shared_ptr<Promise<std::vector<ExitProgressStatusResult>>> progressExits(std::optional<double> feeRateSatPerKvb) = 0;
       virtual std::shared_ptr<Promise<std::vector<ExitVtxoResult>>> getExitVtxos() = 0;
       virtual std::shared_ptr<Promise<std::vector<ExitVtxoResult>>> listClaimable() = 0;

--- a/react-native-nitro-ark/package.json
+++ b/react-native-nitro-ark/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-nitro-ark",
-  "version": "0.0.112",
+  "version": "0.0.113",
   "description": "Pure C++ Nitro Modules for Ark client",
   "source": "./src/index.tsx",
   "main": "./lib/module/index.js",

--- a/react-native-nitro-ark/src/NitroArk.nitro.ts
+++ b/react-native-nitro-ark/src/NitroArk.nitro.ts
@@ -91,15 +91,11 @@ export interface ExitBlockRefResult {
 export interface ExitTxOriginResult {
   kind: string;
   confirmed_in?: ExitBlockRefResult;
-  fee_rate_sat_per_kvb?: number;
-  total_fee_sat?: number;
 }
 
 export interface ExitTxStatusResult {
   kind: string;
   txids?: string[];
-  min_fee_rate_sat_per_kvb?: number;
-  min_fee_sat?: number;
   child_txid?: string;
   origin?: ExitTxOriginResult;
   block?: ExitBlockRefResult;
@@ -282,7 +278,6 @@ export interface NitroArk extends HybridObject<{ ios: 'c++'; android: 'c++' }> {
   startExitForEntireWallet(): Promise<void>;
   startExitForVtxos(vtxoIds: string[]): Promise<void>;
   syncExit(): Promise<void>;
-  syncNoProgress(): Promise<void>;
   progressExits(feeRateSatPerKvb?: number): Promise<ExitProgressStatusResult[]>;
   getExitVtxos(): Promise<ExitVtxoResult[]>;
   listClaimable(): Promise<ExitVtxoResult[]>;

--- a/react-native-nitro-ark/src/index.tsx
+++ b/react-native-nitro-ark/src/index.tsx
@@ -290,14 +290,6 @@ export function syncExit(): Promise<void> {
 }
 
 /**
- * Synchronizes tracked exits without advancing their state.
- * @returns A promise that resolves on success.
- */
-export function syncNoProgress(): Promise<void> {
-  return NitroArkHybridObject.syncNoProgress();
-}
-
-/**
  * Progresses tracked exits by one step.
  * @param feeRateSatPerKvb Optional fee rate override in sat/kvB.
  * @returns A promise resolving to simplified exit progress entries.


### PR DESCRIPTION
## Summary

Updates the React Native Nitro Ark bindings for the newer Bark exit API.

- Replace removed Bark wallet constructors with `create_with_exits` / `open_with_exits`, while keeping the onchain wallet managed separately.
- Update exit progression to use `progress_exits_with_bdk(...)` so the optional fee-rate override still applies.
- Update `syncExit` for the new no-argument `sync_exits()` API.
- Remove the deleted `syncNoProgress` API from Rust FFI, Nitro TS, C++, and generated Nitrogen bindings.
- Remove obsolete exit transaction fee/RBF fields from the TS/C++/Rust FFI result shapes.
- Map the new simplified transaction statuses: `awaiting-cpfp-broadcast` and `awaiting-confirmation`.
- Regenerate Nitrogen C++ output and refresh `cpp/generated/ark_cxx.h`.

## Breaking Changes

- `syncNoProgress()` has been removed.
- `ExitTxOriginResult` no longer includes `fee_rate_sat_per_kvb` or `total_fee_sat`.
- `ExitTxStatusResult` no longer includes `min_fee_rate_sat_per_kvb` or `min_fee_sat`.
- High-level exit states are unchanged: `Start`, `Processing`, `AwaitingDelta`, `Claimable`, `ClaimInProgress`, `Claimed`.

## Validation

- `cargo check` in `bark-cpp`
- `yarn typecheck` in `react-native-nitro-ark`

## Notes

The example app did not require changes because it does not call `syncNoProgress` or read the removed transaction fee fields.