### PR TITLE
Require explicit wallet config across Nitro and Android bridges

### DIFF
--- a/bark-cpp/src/utils.rs
+++ b/bark-cpp/src/utils.rs
@@ -124,6 +124,9 @@ impl ConfigOpts {
         if let Some(v) = self.bitcoind_pass {
             cfg.bitcoind_pass = if v.is_empty() { None } else { Some(v) };
         }
+        cfg.htlc_recv_claim_delta = self.htlc_recv_claim_delta;
+        cfg.vtxo_exit_margin = self.vtxo_exit_margin;
+        cfg.round_tx_required_confirmations = self.round_tx_required_confirmations;
         cfg.vtxo_refresh_expiry_threshold = self.vtxo_refresh_expiry_threshold;
         cfg.fallback_fee_rate = self.fallback_fee_rate.map(FeeRate::from_sat_per_kvb_ceil);
 
@@ -294,9 +297,6 @@ pub fn merge_config_opts(opts: CreateOpts) -> anyhow::Result<(Config, Network)> 
     };
 
     let mut config = Config::network_default(net);
-    config.htlc_recv_claim_delta = opts.config.htlc_recv_claim_delta;
-    config.vtxo_exit_margin = opts.config.vtxo_exit_margin;
-    config.round_tx_required_confirmations = opts.config.round_tx_required_confirmations;
     opts.config
         .clone()
         .merge_into(&mut config)

--- a/react-native-nitro-ark/android/src/main/cpp/NitroArkJni.cpp
+++ b/react-native-nitro-ark/android/src/main/cpp/NitroArkJni.cpp
@@ -228,7 +228,7 @@ JNIEXPORT void JNICALL Java_com_margelo_nitro_nitroark_NitroArkNative_loadWallet
     JNIEnv* env, jobject /*thiz*/, jstring jDatadir, jstring jMnemonic, jboolean jRegtest, jboolean jSignet,
     jboolean jBitcoin, jobject jBirthdayHeight, jstring jArk, jstring jServerAccessToken, jstring jEsplora,
     jstring jBitcoind, jstring jBitcoindCookie, jstring jBitcoindUser, jstring jBitcoindPass,
-    jobject jVtxoRefreshExpiryThreshold, jobject jFallbackFeeRate, jobject jHtlcRecvClaimDelta, jobject jVtxoExitMargin,
+    jint jVtxoRefreshExpiryThreshold, jlong jFallbackFeeRate, jobject jHtlcRecvClaimDelta, jobject jVtxoExitMargin,
     jobject jRoundTxRequiredConfirmations) {
   try {
     const std::string datadir = JStringToString(env, jDatadir);
@@ -258,9 +258,8 @@ JNIEXPORT void JNICALL Java_com_margelo_nitro_nitroark_NitroArkNative_loadWallet
     config.bitcoind_user = JStringToString(env, jBitcoindUser);
     config.bitcoind_pass = JStringToString(env, jBitcoindPass);
 
-    config.vtxo_refresh_expiry_threshold =
-        static_cast<uint32_t>(GetOptionalInt(env, jVtxoRefreshExpiryThreshold).value_or(0));
-    config.fallback_fee_rate = static_cast<uint64_t>(GetOptionalLong(env, jFallbackFeeRate).value_or(0));
+    config.vtxo_refresh_expiry_threshold = static_cast<uint32_t>(jVtxoRefreshExpiryThreshold);
+    config.fallback_fee_rate = static_cast<uint64_t>(jFallbackFeeRate);
     config.htlc_recv_claim_delta = static_cast<uint16_t>(GetOptionalInt(env, jHtlcRecvClaimDelta).value_or(0));
     config.vtxo_exit_margin = static_cast<uint16_t>(GetOptionalInt(env, jVtxoExitMargin).value_or(0));
     config.round_tx_required_confirmations =

--- a/react-native-nitro-ark/android/src/main/java/com/margelo/nitro/nitroark/NitroArkNative.kt
+++ b/react-native-nitro-ark/android/src/main/java/com/margelo/nitro/nitroark/NitroArkNative.kt
@@ -8,15 +8,15 @@ import android.util.Log
  */
 object NitroArkNative {
   data class AndroidBarkConfig(
-      val ark: String? = null,
+      val ark: String,
+      val vtxoRefreshExpiryThreshold: Int,
+      val fallbackFeeRate: Long,
       val serverAccessToken: String? = null,
       val esplora: String? = null,
       val bitcoind: String? = null,
       val bitcoindCookie: String? = null,
       val bitcoindUser: String? = null,
       val bitcoindPass: String? = null,
-      val vtxoRefreshExpiryThreshold: Int? = null,
-      val fallbackFeeRate: Long? = null,
       val htlcRecvClaimDelta: Int? = null,
       val vtxoExitMargin: Int? = null,
       val roundTxRequiredConfirmations: Int? = null,
@@ -28,7 +28,7 @@ object NitroArkNative {
   }
 
   /**
-   * Load an existing wallet using optional chain/config overrides.
+   * Load an existing wallet using explicit chain/config values.
    */
   fun loadWallet(
       datadir: String,
@@ -37,7 +37,7 @@ object NitroArkNative {
       signet: Boolean = false,
       bitcoin: Boolean = true,
       birthdayHeight: Int? = null,
-      config: AndroidBarkConfig? = null
+      config: AndroidBarkConfig
   ) {
     Log.i("NitroArkNative", "loadWallet(datadir=$datadir regtest=$regtest signet=$signet bitcoin=$bitcoin)")
     loadWalletNative(
@@ -47,18 +47,18 @@ object NitroArkNative {
         signet,
         bitcoin,
         birthdayHeight,
-        config?.ark,
-        config?.serverAccessToken,
-        config?.esplora,
-        config?.bitcoind,
-        config?.bitcoindCookie,
-        config?.bitcoindUser,
-        config?.bitcoindPass,
-        config?.vtxoRefreshExpiryThreshold,
-        config?.fallbackFeeRate,
-        config?.htlcRecvClaimDelta,
-        config?.vtxoExitMargin,
-        config?.roundTxRequiredConfirmations)
+        config.ark,
+        config.serverAccessToken,
+        config.esplora,
+        config.bitcoind,
+        config.bitcoindCookie,
+        config.bitcoindUser,
+        config.bitcoindPass,
+        config.vtxoRefreshExpiryThreshold,
+        config.fallbackFeeRate,
+        config.htlcRecvClaimDelta,
+        config.vtxoExitMargin,
+        config.roundTxRequiredConfirmations)
   }
 
   external fun isWalletLoaded(): Boolean
@@ -72,15 +72,15 @@ object NitroArkNative {
       signet: Boolean,
       bitcoin: Boolean,
       birthdayHeight: Int?,
-      ark: String?,
+      ark: String,
       serverAccessToken: String?,
       esplora: String?,
       bitcoind: String?,
       bitcoindCookie: String?,
       bitcoindUser: String?,
       bitcoindPass: String?,
-      vtxoRefreshExpiryThreshold: Int?,
-      fallbackFeeRate: Long?,
+      vtxoRefreshExpiryThreshold: Int,
+      fallbackFeeRate: Long,
       htlcRecvClaimDelta: Int?,
       vtxoExitMargin: Int?,
       roundTxRequiredConfirmations: Int?,

--- a/react-native-nitro-ark/cpp/NitroArk.hpp
+++ b/react-native-nitro-ark/cpp/NitroArk.hpp
@@ -266,7 +266,7 @@ private:
   static bark_cxx::ConfigOpts createConfigOpts(const std::optional<BarkConfigOpts>& config) {
     bark_cxx::ConfigOpts config_opts;
     if (config.has_value()) {
-      config_opts.ark = config->ark.value_or("");
+      config_opts.ark = config->ark;
       config_opts.server_access_token = config->server_access_token.value_or("");
       config_opts.esplora = config->esplora.value_or("");
       config_opts.bitcoind = config->bitcoind.value_or("");
@@ -274,8 +274,8 @@ private:
       config_opts.bitcoind_user = config->bitcoind_user.value_or("");
       config_opts.bitcoind_pass = config->bitcoind_pass.value_or("");
       config_opts.vtxo_refresh_expiry_threshold =
-          static_cast<uint32_t>(config->vtxo_refresh_expiry_threshold.value_or(0));
-      config_opts.fallback_fee_rate = static_cast<uint64_t>(config->fallback_fee_rate.value_or(0));
+          static_cast<uint32_t>(config->vtxo_refresh_expiry_threshold);
+      config_opts.fallback_fee_rate = static_cast<uint64_t>(config->fallback_fee_rate);
       config_opts.htlc_recv_claim_delta = static_cast<uint32_t>(config->htlc_recv_claim_delta);
       config_opts.vtxo_exit_margin = static_cast<uint32_t>(config->vtxo_exit_margin);
       config_opts.round_tx_required_confirmations = static_cast<uint32_t>(config->round_tx_required_confirmations);

--- a/react-native-nitro-ark/example/android/app/src/main/java/nitroark/example/NitroArkDemoModule.kt
+++ b/react-native-nitro-ark/example/android/app/src/main/java/nitroark/example/NitroArkDemoModule.kt
@@ -25,17 +25,17 @@ class NitroArkDemoModule(reactContext: ReactApplicationContext) :
         Log.i(NAME, "loadWallet nested config: $nestedConfig")
       }
 
-      val parsedConfig = nestedConfig?.let { map ->
+      val parsedConfig = requireNotNull(nestedConfig) { "Missing required wallet config." }.let { map ->
         NitroArkNative.AndroidBarkConfig(
-            ark = map.getStringOrNull("ark"),
+            ark = map.getRequiredString("ark"),
             serverAccessToken = map.getStringOrNull("server_access_token"),
             esplora = map.getStringOrNull("esplora"),
             bitcoind = map.getStringOrNull("bitcoind"),
             bitcoindCookie = map.getStringOrNull("bitcoind_cookie"),
             bitcoindUser = map.getStringOrNull("bitcoind_user"),
             bitcoindPass = map.getStringOrNull("bitcoind_pass"),
-            vtxoRefreshExpiryThreshold = map.getIntOrNull("vtxo_refresh_expiry_threshold"),
-            fallbackFeeRate = map.getLongOrNull("fallback_fee_rate"),
+            vtxoRefreshExpiryThreshold = map.getRequiredInt("vtxo_refresh_expiry_threshold"),
+            fallbackFeeRate = map.getRequiredLong("fallback_fee_rate"),
             htlcRecvClaimDelta = map.getIntOrNull("htlc_recv_claim_delta"),
             vtxoExitMargin = map.getIntOrNull("vtxo_exit_margin"),
             roundTxRequiredConfirmations = map.getIntOrNull("round_tx_required_confirmations"),
@@ -173,11 +173,20 @@ class NitroArkDemoModule(reactContext: ReactApplicationContext) :
 private fun ReadableMap.getStringOrNull(key: String): String? =
     if (hasKey(key) && !isNull(key)) getString(key) else null
 
+private fun ReadableMap.getRequiredString(key: String): String =
+    requireNotNull(getStringOrNull(key)) { "Missing required config value '$key'." }
+
 private fun ReadableMap.getIntOrNull(key: String): Int? =
     if (hasKey(key) && !isNull(key)) getInt(key) else null
 
+private fun ReadableMap.getRequiredInt(key: String): Int =
+    requireNotNull(getIntOrNull(key)) { "Missing required config value '$key'." }
+
 private fun ReadableMap.getLongOrNull(key: String): Long? =
     if (hasKey(key) && !isNull(key)) getDouble(key).toLong() else null
+
+private fun ReadableMap.getRequiredLong(key: String): Long =
+    requireNotNull(getLongOrNull(key)) { "Missing required config value '$key'." }
 
 private fun ReadableMap.getBooleanOrDefault(key: String, defaultValue: Boolean): Boolean =
     if (hasKey(key) && !isNull(key)) getBoolean(key) else defaultValue

--- a/react-native-nitro-ark/example/ios/Podfile.lock
+++ b/react-native-nitro-ark/example/ios/Podfile.lock
@@ -3,7 +3,7 @@ PODS:
   - hermes-engine (250829098.0.10):
     - hermes-engine/Pre-built (= 250829098.0.10)
   - hermes-engine/Pre-built (250829098.0.10)
-  - NitroArk (0.0.119):
+  - NitroArk (0.0.120):
     - hermes-engine
     - NitroModules
     - RCTRequired
@@ -2122,7 +2122,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   FBLazyVector: 24e62c765683b8d89006a88a2c8f5cf019f0074d
   hermes-engine: b9bc07e8e3778c44d446d1bfa9788de105e5c157
-  NitroArk: 5dda3eab42fe7875640604d0bbcfe3698d5c69f9
+  NitroArk: c21050b0ca711182b4c3949f5b02f330fc84c5fb
   NitroModules: ba9ddd723ffde85412ec774827d4a80ad9864b89
   RCTDeprecation: a4c521821fab57cbb125b36effe84d897d0dfa12
   RCTRequired: 9f3a7e5645d4bc3f551593de7550bb66ab6e42bc

--- a/react-native-nitro-ark/example/src/tabs/SendTab.tsx
+++ b/react-native-nitro-ark/example/src/tabs/SendTab.tsx
@@ -304,7 +304,12 @@ export const SendTab = ({
       'payLightningAddress',
       async () => {
         await showLightningSendFeeEstimate(amount);
-        return NitroArk.payLightningAddress(arkDestination, amount, arkComment, false);
+        return NitroArk.payLightningAddress(
+          arkDestination,
+          amount,
+          arkComment,
+          false
+        );
       },
       'lightning'
     );

--- a/react-native-nitro-ark/nitrogen/generated/shared/c++/BarkConfigOpts.hpp
+++ b/react-native-nitro-ark/nitrogen/generated/shared/c++/BarkConfigOpts.hpp
@@ -40,22 +40,22 @@ namespace margelo::nitro::nitroark {
    */
   struct BarkConfigOpts final {
   public:
-    std::optional<std::string> ark     SWIFT_PRIVATE;
+    std::string ark     SWIFT_PRIVATE;
     std::optional<std::string> server_access_token     SWIFT_PRIVATE;
     std::optional<std::string> esplora     SWIFT_PRIVATE;
     std::optional<std::string> bitcoind     SWIFT_PRIVATE;
     std::optional<std::string> bitcoind_cookie     SWIFT_PRIVATE;
     std::optional<std::string> bitcoind_user     SWIFT_PRIVATE;
     std::optional<std::string> bitcoind_pass     SWIFT_PRIVATE;
-    std::optional<double> vtxo_refresh_expiry_threshold     SWIFT_PRIVATE;
-    std::optional<double> fallback_fee_rate     SWIFT_PRIVATE;
+    double vtxo_refresh_expiry_threshold     SWIFT_PRIVATE;
+    double fallback_fee_rate     SWIFT_PRIVATE;
     double htlc_recv_claim_delta     SWIFT_PRIVATE;
     double vtxo_exit_margin     SWIFT_PRIVATE;
     double round_tx_required_confirmations     SWIFT_PRIVATE;
 
   public:
     BarkConfigOpts() = default;
-    explicit BarkConfigOpts(std::optional<std::string> ark, std::optional<std::string> server_access_token, std::optional<std::string> esplora, std::optional<std::string> bitcoind, std::optional<std::string> bitcoind_cookie, std::optional<std::string> bitcoind_user, std::optional<std::string> bitcoind_pass, std::optional<double> vtxo_refresh_expiry_threshold, std::optional<double> fallback_fee_rate, double htlc_recv_claim_delta, double vtxo_exit_margin, double round_tx_required_confirmations): ark(ark), server_access_token(server_access_token), esplora(esplora), bitcoind(bitcoind), bitcoind_cookie(bitcoind_cookie), bitcoind_user(bitcoind_user), bitcoind_pass(bitcoind_pass), vtxo_refresh_expiry_threshold(vtxo_refresh_expiry_threshold), fallback_fee_rate(fallback_fee_rate), htlc_recv_claim_delta(htlc_recv_claim_delta), vtxo_exit_margin(vtxo_exit_margin), round_tx_required_confirmations(round_tx_required_confirmations) {}
+    explicit BarkConfigOpts(std::string ark, std::optional<std::string> server_access_token, std::optional<std::string> esplora, std::optional<std::string> bitcoind, std::optional<std::string> bitcoind_cookie, std::optional<std::string> bitcoind_user, std::optional<std::string> bitcoind_pass, double vtxo_refresh_expiry_threshold, double fallback_fee_rate, double htlc_recv_claim_delta, double vtxo_exit_margin, double round_tx_required_confirmations): ark(ark), server_access_token(server_access_token), esplora(esplora), bitcoind(bitcoind), bitcoind_cookie(bitcoind_cookie), bitcoind_user(bitcoind_user), bitcoind_pass(bitcoind_pass), vtxo_refresh_expiry_threshold(vtxo_refresh_expiry_threshold), fallback_fee_rate(fallback_fee_rate), htlc_recv_claim_delta(htlc_recv_claim_delta), vtxo_exit_margin(vtxo_exit_margin), round_tx_required_confirmations(round_tx_required_confirmations) {}
 
   public:
     friend bool operator==(const BarkConfigOpts& lhs, const BarkConfigOpts& rhs) = default;
@@ -71,15 +71,15 @@ namespace margelo::nitro {
     static inline margelo::nitro::nitroark::BarkConfigOpts fromJSI(jsi::Runtime& runtime, const jsi::Value& arg) {
       jsi::Object obj = arg.asObject(runtime);
       return margelo::nitro::nitroark::BarkConfigOpts(
-        JSIConverter<std::optional<std::string>>::fromJSI(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "ark"))),
+        JSIConverter<std::string>::fromJSI(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "ark"))),
         JSIConverter<std::optional<std::string>>::fromJSI(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "server_access_token"))),
         JSIConverter<std::optional<std::string>>::fromJSI(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "esplora"))),
         JSIConverter<std::optional<std::string>>::fromJSI(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "bitcoind"))),
         JSIConverter<std::optional<std::string>>::fromJSI(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "bitcoind_cookie"))),
         JSIConverter<std::optional<std::string>>::fromJSI(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "bitcoind_user"))),
         JSIConverter<std::optional<std::string>>::fromJSI(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "bitcoind_pass"))),
-        JSIConverter<std::optional<double>>::fromJSI(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "vtxo_refresh_expiry_threshold"))),
-        JSIConverter<std::optional<double>>::fromJSI(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "fallback_fee_rate"))),
+        JSIConverter<double>::fromJSI(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "vtxo_refresh_expiry_threshold"))),
+        JSIConverter<double>::fromJSI(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "fallback_fee_rate"))),
         JSIConverter<double>::fromJSI(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "htlc_recv_claim_delta"))),
         JSIConverter<double>::fromJSI(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "vtxo_exit_margin"))),
         JSIConverter<double>::fromJSI(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "round_tx_required_confirmations")))
@@ -87,15 +87,15 @@ namespace margelo::nitro {
     }
     static inline jsi::Value toJSI(jsi::Runtime& runtime, const margelo::nitro::nitroark::BarkConfigOpts& arg) {
       jsi::Object obj(runtime);
-      obj.setProperty(runtime, PropNameIDCache::get(runtime, "ark"), JSIConverter<std::optional<std::string>>::toJSI(runtime, arg.ark));
+      obj.setProperty(runtime, PropNameIDCache::get(runtime, "ark"), JSIConverter<std::string>::toJSI(runtime, arg.ark));
       obj.setProperty(runtime, PropNameIDCache::get(runtime, "server_access_token"), JSIConverter<std::optional<std::string>>::toJSI(runtime, arg.server_access_token));
       obj.setProperty(runtime, PropNameIDCache::get(runtime, "esplora"), JSIConverter<std::optional<std::string>>::toJSI(runtime, arg.esplora));
       obj.setProperty(runtime, PropNameIDCache::get(runtime, "bitcoind"), JSIConverter<std::optional<std::string>>::toJSI(runtime, arg.bitcoind));
       obj.setProperty(runtime, PropNameIDCache::get(runtime, "bitcoind_cookie"), JSIConverter<std::optional<std::string>>::toJSI(runtime, arg.bitcoind_cookie));
       obj.setProperty(runtime, PropNameIDCache::get(runtime, "bitcoind_user"), JSIConverter<std::optional<std::string>>::toJSI(runtime, arg.bitcoind_user));
       obj.setProperty(runtime, PropNameIDCache::get(runtime, "bitcoind_pass"), JSIConverter<std::optional<std::string>>::toJSI(runtime, arg.bitcoind_pass));
-      obj.setProperty(runtime, PropNameIDCache::get(runtime, "vtxo_refresh_expiry_threshold"), JSIConverter<std::optional<double>>::toJSI(runtime, arg.vtxo_refresh_expiry_threshold));
-      obj.setProperty(runtime, PropNameIDCache::get(runtime, "fallback_fee_rate"), JSIConverter<std::optional<double>>::toJSI(runtime, arg.fallback_fee_rate));
+      obj.setProperty(runtime, PropNameIDCache::get(runtime, "vtxo_refresh_expiry_threshold"), JSIConverter<double>::toJSI(runtime, arg.vtxo_refresh_expiry_threshold));
+      obj.setProperty(runtime, PropNameIDCache::get(runtime, "fallback_fee_rate"), JSIConverter<double>::toJSI(runtime, arg.fallback_fee_rate));
       obj.setProperty(runtime, PropNameIDCache::get(runtime, "htlc_recv_claim_delta"), JSIConverter<double>::toJSI(runtime, arg.htlc_recv_claim_delta));
       obj.setProperty(runtime, PropNameIDCache::get(runtime, "vtxo_exit_margin"), JSIConverter<double>::toJSI(runtime, arg.vtxo_exit_margin));
       obj.setProperty(runtime, PropNameIDCache::get(runtime, "round_tx_required_confirmations"), JSIConverter<double>::toJSI(runtime, arg.round_tx_required_confirmations));
@@ -109,15 +109,15 @@ namespace margelo::nitro {
       if (!nitro::isPlainObject(runtime, obj)) {
         return false;
       }
-      if (!JSIConverter<std::optional<std::string>>::canConvert(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "ark")))) return false;
+      if (!JSIConverter<std::string>::canConvert(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "ark")))) return false;
       if (!JSIConverter<std::optional<std::string>>::canConvert(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "server_access_token")))) return false;
       if (!JSIConverter<std::optional<std::string>>::canConvert(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "esplora")))) return false;
       if (!JSIConverter<std::optional<std::string>>::canConvert(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "bitcoind")))) return false;
       if (!JSIConverter<std::optional<std::string>>::canConvert(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "bitcoind_cookie")))) return false;
       if (!JSIConverter<std::optional<std::string>>::canConvert(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "bitcoind_user")))) return false;
       if (!JSIConverter<std::optional<std::string>>::canConvert(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "bitcoind_pass")))) return false;
-      if (!JSIConverter<std::optional<double>>::canConvert(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "vtxo_refresh_expiry_threshold")))) return false;
-      if (!JSIConverter<std::optional<double>>::canConvert(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "fallback_fee_rate")))) return false;
+      if (!JSIConverter<double>::canConvert(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "vtxo_refresh_expiry_threshold")))) return false;
+      if (!JSIConverter<double>::canConvert(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "fallback_fee_rate")))) return false;
       if (!JSIConverter<double>::canConvert(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "htlc_recv_claim_delta")))) return false;
       if (!JSIConverter<double>::canConvert(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "vtxo_exit_margin")))) return false;
       if (!JSIConverter<double>::canConvert(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "round_tx_required_confirmations")))) return false;

--- a/react-native-nitro-ark/package.json
+++ b/react-native-nitro-ark/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-nitro-ark",
-  "version": "0.0.119",
+  "version": "0.0.120",
   "description": "Pure C++ Nitro Modules for Ark client",
   "source": "./src/index.tsx",
   "main": "./lib/module/index.js",

--- a/react-native-nitro-ark/src/NitroArk.nitro.ts
+++ b/react-native-nitro-ark/src/NitroArk.nitro.ts
@@ -5,15 +5,15 @@ import type { HybridObject } from 'react-native-nitro-modules';
 // Note: BarkError is handled via Promise rejection, not exposed directly.
 
 export interface BarkConfigOpts {
-  ark?: string;
+  ark: string;
   server_access_token?: string;
   esplora?: string;
   bitcoind?: string;
   bitcoind_cookie?: string;
   bitcoind_user?: string;
   bitcoind_pass?: string;
-  vtxo_refresh_expiry_threshold?: number;
-  fallback_fee_rate?: number;
+  vtxo_refresh_expiry_threshold: number;
+  fallback_fee_rate: number;
   htlc_recv_claim_delta: number;
   vtxo_exit_margin: number;
   round_tx_required_confirmations: number;


### PR DESCRIPTION
## Summary
- Make `ark`, `vtxo_refresh_expiry_threshold`, and `fallback_fee_rate` required in `NitroArk.nitro.ts` so the native contract is explicit.
- Regenerate the Nitro C++ bindings so the generated `BarkConfigOpts` no longer treats those values as optional.
- Update the C++ and Rust bridge code so config merging happens in one place inside `merge_into`.
- Align the Android JNI facade and example module with the same required-config contract.
- Include the package version / Podfile lock refresh and the small example formatting update already in the worktree.

## Testing
- `yarn typecheck`
- `cargo test --manifest-path bark-cpp/Cargo.toml`
- `yarn lint` passed aside from the existing Browserslist warning
- Android Gradle compile was attempted, but the example `settings.gradle` failed while invoking `npx` with exit code 126