### PR TITLE
Add wallet DB generation access and example polling

### DIFF
--- a/bark-cpp/Cargo.lock
+++ b/bark-cpp/Cargo.lock
@@ -119,7 +119,6 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 [[package]]
 name = "ark-lib"
 version = "0.2.5"
-source = "git+https://gitlab.com/ark-bitcoin/bark.git?rev=b9040f1dbf1a99634d20b18fc1c5890de0582942#b9040f1dbf1a99634d20b18fc1c5890de0582942"
 dependencies = [
  "async-trait",
  "bark-bitcoin-ext",
@@ -174,7 +173,6 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 [[package]]
 name = "bark-bitcoin-ext"
 version = "0.2.5"
-source = "git+https://gitlab.com/ark-bitcoin/bark.git?rev=b9040f1dbf1a99634d20b18fc1c5890de0582942#b9040f1dbf1a99634d20b18fc1c5890de0582942"
 dependencies = [
  "bdk_bitcoind_rpc",
  "bdk_wallet",
@@ -213,7 +211,6 @@ dependencies = [
 [[package]]
 name = "bark-server-rpc"
 version = "0.2.5"
-source = "git+https://gitlab.com/ark-bitcoin/bark.git?rev=b9040f1dbf1a99634d20b18fc1c5890de0582942#b9040f1dbf1a99634d20b18fc1c5890de0582942"
 dependencies = [
  "ark-lib",
  "bitcoin",
@@ -231,7 +228,6 @@ dependencies = [
 [[package]]
 name = "bark-wallet"
 version = "0.2.5"
-source = "git+https://gitlab.com/ark-bitcoin/bark.git?rev=b9040f1dbf1a99634d20b18fc1c5890de0582942#b9040f1dbf1a99634d20b18fc1c5890de0582942"
 dependencies = [
  "anyhow",
  "ark-lib",
@@ -366,7 +362,6 @@ checksum = "32637268377fc7b10a8c6d51de3e7fba1ce5dd371a96e342b34e6078db558e7f"
 [[package]]
 name = "bip321"
 version = "0.1.0"
-source = "git+https://gitlab.com/ark-bitcoin/bark.git?rev=b9040f1dbf1a99634d20b18fc1c5890de0582942#b9040f1dbf1a99634d20b18fc1c5890de0582942"
 dependencies = [
  "bitcoin",
  "lightning",

--- a/bark-cpp/Cargo.toml
+++ b/bark-cpp/Cargo.toml
@@ -52,3 +52,7 @@ strip = true # Strip symbols from binary
 [dev-dependencies]
 tempfile = "3.23.0"
 serde_json = "1.0"
+
+[patch."https://gitlab.com/ark-bitcoin/bark.git"]
+bark-wallet = { path = "../../bark/bark" }
+bark-bitcoin-ext = { path = "../../bark/bitcoin-ext" }

--- a/bark-cpp/src/cxx.rs
+++ b/bark-cpp/src/cxx.rs
@@ -344,6 +344,7 @@ pub(crate) mod ffi {
         fn init_logger();
         fn create_mnemonic() -> Result<String>;
         fn is_wallet_loaded() -> bool;
+        fn get_wallet_db_generation() -> u64;
         fn close_wallet() -> Result<()>;
         fn get_ark_info() -> Result<CxxArkInfo>;
         fn offchain_balance() -> Result<OffchainBalance>;
@@ -494,6 +495,10 @@ pub(crate) fn create_mnemonic() -> anyhow::Result<String> {
 
 pub(crate) fn is_wallet_loaded() -> bool {
     crate::TOKIO_RUNTIME.block_on(crate::is_wallet_loaded())
+}
+
+pub(crate) fn get_wallet_db_generation() -> u64 {
+    crate::get_wallet_db_generation()
 }
 
 pub(crate) fn close_wallet() -> anyhow::Result<()> {

--- a/bark-cpp/src/lib.rs
+++ b/bark-cpp/src/lib.rs
@@ -302,6 +302,10 @@ pub async fn is_wallet_loaded() -> bool {
     manager.is_loaded()
 }
 
+pub fn get_wallet_db_generation() -> u64 {
+    bark::persist::sqlite::wallet_db_generation()
+}
+
 pub async fn balance() -> anyhow::Result<bark::Balance> {
     let mut manager = GLOBAL_WALLET_MANAGER.lock().await;
     manager

--- a/react-native-nitro-ark/cpp/NitroArk.hpp
+++ b/react-native-nitro-ark/cpp/NitroArk.hpp
@@ -400,6 +400,10 @@ public:
     return Promise<bool>::async([]() { return bark_cxx::is_wallet_loaded(); });
   }
 
+  std::shared_ptr<Promise<double>> getWalletDbGeneration() override {
+    return Promise<double>::async([]() { return static_cast<double>(bark_cxx::get_wallet_db_generation()); });
+  }
+
   std::shared_ptr<Promise<void>> syncPendingBoards() override {
     return Promise<void>::async([]() {
       try {

--- a/react-native-nitro-ark/cpp/generated/ark_cxx.h
+++ b/react-native-nitro-ark/cpp/generated/ark_cxx.h
@@ -1496,6 +1496,8 @@ void init_logger() noexcept;
 
 bool is_wallet_loaded() noexcept;
 
+::std::uint64_t get_wallet_db_generation() noexcept;
+
 void close_wallet();
 
 ::bark_cxx::CxxArkInfo get_ark_info();

--- a/react-native-nitro-ark/example/src/App.tsx
+++ b/react-native-nitro-ark/example/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import {
   View,
   Text,
@@ -10,10 +10,11 @@ import {
 import RNFSTurbo from 'react-native-fs-turbo';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 
-import type {
-  BarkArkInfo,
-  OnchainBalanceResult,
-  OffchainBalanceResult,
+import {
+  getWalletDbGeneration,
+  type BarkArkInfo,
+  type OnchainBalanceResult,
+  type OffchainBalanceResult,
 } from 'react-native-nitro-ark';
 
 import { WalletTab } from './tabs/WalletTab';
@@ -40,6 +41,10 @@ export default function App() {
 
   // Wallet loaded state
   const [isWalletLoaded, setIsWalletLoaded] = useState(false);
+  const [walletDbGeneration, setWalletDbGeneration] = useState<
+    number | undefined
+  >();
+  const lastLoggedWalletDbGenerationRef = useRef<number | undefined>(undefined);
 
   // UI state
   const [results, setResults] = useState<{ [key: string]: string }>({});
@@ -78,6 +83,46 @@ export default function App() {
       }
     };
     loadSavedMnemonic();
+  }, []);
+
+  // Poll the native wallet DB generation counter so the example app logs
+  // whenever Bark commits wallet SQLite changes.
+  useEffect(() => {
+    let isActive = true;
+
+    const pollWalletDbGeneration = async () => {
+      try {
+        const generation = await getWalletDbGeneration();
+        if (!isActive) {
+          return;
+        }
+
+        setWalletDbGeneration(generation);
+
+        const previous = lastLoggedWalletDbGenerationRef.current;
+        if (previous === undefined) {
+          console.log('[wallet-db] initial generation:', generation);
+        } else if (generation !== previous) {
+          console.log('[wallet-db] generation changed:', {
+            previous,
+            generation,
+          });
+        }
+        lastLoggedWalletDbGenerationRef.current = generation;
+      } catch (err) {
+        console.error('Error polling wallet DB generation:', err);
+      }
+    };
+
+    void pollWalletDbGeneration();
+    const interval = setInterval(() => {
+      void pollWalletDbGeneration();
+    }, 1000);
+
+    return () => {
+      isActive = false;
+      clearInterval(interval);
+    };
   }, []);
 
   // Generic operation runner
@@ -169,6 +214,19 @@ export default function App() {
             />
             <Text style={styles.statusLabel}>
               {isWalletLoaded ? 'Wallet Loaded' : 'Not Loaded'}
+            </Text>
+          </View>
+          <View style={styles.headerStatusRow}>
+            <View
+              style={[
+                styles.statusDot,
+                walletDbGeneration !== undefined
+                  ? styles.statusActive
+                  : styles.statusInactive,
+              ]}
+            />
+            <Text style={styles.statusLabel}>
+              DB Gen {walletDbGeneration ?? '-'}
             </Text>
           </View>
         </View>

--- a/react-native-nitro-ark/nitrogen/generated/shared/c++/HybridNitroArkSpec.cpp
+++ b/react-native-nitro-ark/nitrogen/generated/shared/c++/HybridNitroArkSpec.cpp
@@ -18,6 +18,7 @@ namespace margelo::nitro::nitroark {
       prototype.registerHybridMethod("createWallet", &HybridNitroArkSpec::createWallet);
       prototype.registerHybridMethod("loadWallet", &HybridNitroArkSpec::loadWallet);
       prototype.registerHybridMethod("isWalletLoaded", &HybridNitroArkSpec::isWalletLoaded);
+      prototype.registerHybridMethod("getWalletDbGeneration", &HybridNitroArkSpec::getWalletDbGeneration);
       prototype.registerHybridMethod("closeWallet", &HybridNitroArkSpec::closeWallet);
       prototype.registerHybridMethod("refreshServer", &HybridNitroArkSpec::refreshServer);
       prototype.registerHybridMethod("syncPendingBoards", &HybridNitroArkSpec::syncPendingBoards);

--- a/react-native-nitro-ark/nitrogen/generated/shared/c++/HybridNitroArkSpec.hpp
+++ b/react-native-nitro-ark/nitrogen/generated/shared/c++/HybridNitroArkSpec.hpp
@@ -131,6 +131,7 @@ namespace margelo::nitro::nitroark {
       virtual std::shared_ptr<Promise<void>> createWallet(const std::string& datadir, const BarkCreateOpts& opts) = 0;
       virtual std::shared_ptr<Promise<void>> loadWallet(const std::string& datadir, const BarkCreateOpts& config) = 0;
       virtual std::shared_ptr<Promise<bool>> isWalletLoaded() = 0;
+      virtual std::shared_ptr<Promise<double>> getWalletDbGeneration() = 0;
       virtual std::shared_ptr<Promise<void>> closeWallet() = 0;
       virtual std::shared_ptr<Promise<void>> refreshServer() = 0;
       virtual std::shared_ptr<Promise<void>> syncPendingBoards() = 0;

--- a/react-native-nitro-ark/src/NitroArk.nitro.ts
+++ b/react-native-nitro-ark/src/NitroArk.nitro.ts
@@ -293,6 +293,7 @@ export interface NitroArk extends HybridObject<{ ios: 'c++'; android: 'c++' }> {
   createWallet(datadir: string, opts: BarkCreateOpts): Promise<void>;
   loadWallet(datadir: string, config: BarkCreateOpts): Promise<void>;
   isWalletLoaded(): Promise<boolean>;
+  getWalletDbGeneration(): Promise<number>;
   closeWallet(): Promise<void>;
   refreshServer(): Promise<void>;
   syncPendingBoards(): Promise<void>;

--- a/react-native-nitro-ark/src/index.tsx
+++ b/react-native-nitro-ark/src/index.tsx
@@ -230,6 +230,13 @@ export function isWalletLoaded(): Promise<boolean> {
 }
 
 /**
+ * Returns the number of wallet SQLite commits observed in the current native process.
+ */
+export function getWalletDbGeneration(): Promise<number> {
+  return NitroArkHybridObject.getWalletDbGeneration();
+}
+
+/**
  * Registers all confirmed boards with the server.
  * @returns A promise that resolves on success.
  */

--- a/scripts/docker-compose.yml
+++ b/scripts/docker-compose.yml
@@ -68,7 +68,7 @@ services:
         condition: service_healthy
 
   captaind:
-    image: niteshbalusu/captaind:nightly-2026-05-28
+    image: niteshbalusu/captaind:nightly-2026-06-15
     volumes:
       - captaind:/data/captaind
       - ./captaind.toml:/data/captaind/captaind.toml
@@ -87,7 +87,7 @@ services:
         condition: service_healthy
 
   bark:
-    image: niteshbalusu/bark:nightly-2026-05-28
+    image: niteshbalusu/bark:nightly-2026-06-15
     volumes:
       - bark:/root
     depends_on:


### PR DESCRIPTION
## Summary
- expose the native wallet SQLite generation counter through bark-cpp and NitroArk
- wire the new API into the C++ bridge and TypeScript surface
- update the example app to poll and display wallet DB generation changes
- refresh local Bark/Captaind Docker image tags and patch bark dependencies to local paths

## Testing
- Not run (not requested)