### PR TITLE
Add user-agent support and expose the Bark version

### DIFF
--- a/bark-cpp/Cargo.lock
+++ b/bark-cpp/Cargo.lock
@@ -209,6 +209,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-util",
+ "toml",
  "tonic",
 ]
 
@@ -2937,10 +2938,12 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
+ "indexmap",
  "serde_core",
  "serde_spanned",
  "toml_datetime",
  "toml_parser",
+ "toml_writer",
  "winnow",
 ]
 
@@ -2961,6 +2964,12 @@ checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
  "winnow",
 ]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tonic"

--- a/bark-cpp/Cargo.toml
+++ b/bark-cpp/Cargo.toml
@@ -38,6 +38,7 @@ tempfile = "3.23.0"
 
 [build-dependencies]
 cxx-build = "1.0.186"
+toml = "1.0"
 
 [lib]
 crate-type = ["staticlib"]

--- a/bark-cpp/build.rs
+++ b/bark-cpp/build.rs
@@ -1,7 +1,42 @@
+use std::path::PathBuf;
+
+fn resolved_bark_wallet_version() -> String {
+    let lockfile_path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("Cargo.lock");
+    let lockfile = std::fs::read_to_string(&lockfile_path)
+        .unwrap_or_else(|error| panic!("failed to read {}: {error}", lockfile_path.display()));
+    let lockfile: toml::Value = toml::from_str(&lockfile)
+        .unwrap_or_else(|error| panic!("failed to parse {}: {error}", lockfile_path.display()));
+    let packages = lockfile
+        .get("package")
+        .and_then(toml::Value::as_array)
+        .expect("Cargo.lock is missing its package list");
+    let bark_packages: Vec<_> = packages
+        .iter()
+        .filter(|package| package.get("name").and_then(toml::Value::as_str) == Some("bark-wallet"))
+        .collect();
+
+    assert_eq!(
+        bark_packages.len(),
+        1,
+        "expected exactly one resolved bark-wallet package in Cargo.lock"
+    );
+
+    bark_packages[0]
+        .get("version")
+        .and_then(toml::Value::as_str)
+        .expect("resolved bark-wallet package is missing its version")
+        .to_owned()
+}
+
 fn main() {
     // Tell cargo to invalidate the built crate whenever the wrapper changes
     println!("cargo:rerun-if-changed=src/lib.rs");
     println!("cargo:rerun-if-changed=src/cxx.rs");
+    println!("cargo:rerun-if-changed=Cargo.lock");
+    println!(
+        "cargo:rustc-env=BARK_WALLET_VERSION={}",
+        resolved_bark_wallet_version()
+    );
 
     cxx_build::bridge("src/cxx.rs")
         .flag_if_supported("-std=c++17")

--- a/bark-cpp/src/cxx.rs
+++ b/bark-cpp/src/cxx.rs
@@ -211,6 +211,7 @@ pub(crate) mod ffi {
     pub struct ConfigOpts {
         ark: String,
         server_access_token: String,
+        user_agent: String,
         esplora: String,
         bitcoind: String,
         bitcoind_cookie: String,
@@ -379,6 +380,7 @@ pub(crate) mod ffi {
         type StateChangeSubscription;
 
         fn init_logger();
+        fn bark_version() -> String;
         fn create_mnemonic() -> Result<String>;
         fn is_wallet_loaded() -> bool;
         fn close_wallet() -> Result<()>;
@@ -540,6 +542,10 @@ pub(crate) mod ffi {
 
 pub(crate) fn init_logger() {
     crate::init_logger()
+}
+
+pub(crate) fn bark_version() -> String {
+    env!("BARK_WALLET_VERSION").to_owned()
 }
 
 pub(crate) fn create_mnemonic() -> anyhow::Result<String> {

--- a/bark-cpp/src/tests.rs
+++ b/bark-cpp/src/tests.rs
@@ -12,6 +12,11 @@ use tempfile::tempdir;
 
 // --- Test Setup ---
 
+#[test]
+fn bark_version_matches_resolved_build_metadata() {
+    assert_eq!(crate::cxx::bark_version(), env!("BARK_WALLET_VERSION"));
+}
+
 /// Creates a temporary directory and basic wallet creation options for tests.
 fn setup_test_wallet_opts() -> (tempfile::TempDir, ffi::CreateOpts) {
     let temp_dir = tempdir().expect("Failed to create temp dir");
@@ -22,6 +27,7 @@ fn setup_test_wallet_opts() -> (tempfile::TempDir, ffi::CreateOpts) {
         // For real integration tests, these would point to live regtest services.
         ark: "http://127.0.0.1:50051".to_string(),
         server_access_token: "".to_string(),
+        user_agent: "".to_string(),
         esplora: "http://127.0.0.1:3002".to_string(),
         bitcoind: "".to_string(),
         bitcoind_cookie: "".to_string(),
@@ -64,6 +70,36 @@ fn ffi_config_to_config_maps_non_empty_server_access_token_to_some() {
         create_opts.config.server_access_token,
         Some("private-token".to_string())
     );
+}
+
+#[test]
+fn ffi_config_to_config_maps_empty_user_agent_to_none() {
+    let (_temp_dir, opts) = setup_test_wallet_opts();
+    let create_opts = crate::utils::ffi_config_to_config(opts).unwrap();
+
+    assert_eq!(create_opts.config.user_agent, None);
+}
+
+#[test]
+fn ffi_config_to_config_maps_non_empty_user_agent_to_some() {
+    let (_temp_dir, mut opts) = setup_test_wallet_opts();
+    opts.config.user_agent = "someapp-android/0.0.1".to_string();
+    let create_opts = crate::utils::ffi_config_to_config(opts).unwrap();
+
+    assert_eq!(
+        create_opts.config.user_agent,
+        Some("someapp-android/0.0.1".to_string())
+    );
+}
+
+#[test]
+fn merge_config_opts_sets_bark_user_agent() {
+    let (_temp_dir, mut opts) = setup_test_wallet_opts();
+    opts.config.user_agent = "someapp-ios/0.0.1".to_string();
+    let create_opts = crate::utils::ffi_config_to_config(opts).unwrap();
+    let (config, _network) = crate::utils::merge_config_opts(create_opts).unwrap();
+
+    assert_eq!(config.user_agent.as_deref(), Some("someapp-ios/0.0.1"));
 }
 
 #[test]

--- a/bark-cpp/src/utils.rs
+++ b/bark-cpp/src/utils.rs
@@ -128,6 +128,9 @@ impl ConfigOpts {
         if let Some(v) = self.server_access_token {
             cfg.server_access_token = if v.is_empty() { None } else { Some(v) };
         }
+        if let Some(v) = self.user_agent {
+            cfg.user_agent = if v.is_empty() { None } else { Some(v) };
+        }
         if let Some(v) = self.esplora {
             cfg.esplora_address = match v.is_empty() {
                 true => None,
@@ -184,6 +187,7 @@ pub fn https_default_scheme(url: String) -> anyhow::Result<String> {
 pub struct ConfigOpts {
     pub ark: Option<String>,
     pub server_access_token: Option<String>,
+    pub user_agent: Option<String>,
 
     /// The esplora HTTP API endpoint
     pub esplora: Option<String>,
@@ -336,6 +340,11 @@ pub fn ffi_config_to_config(opts: ffi::CreateOpts) -> anyhow::Result<CreateOpts>
             None
         } else {
             Some(opts.config.server_access_token)
+        },
+        user_agent: if opts.config.user_agent.is_empty() {
+            None
+        } else {
+            Some(opts.config.user_agent)
         },
         esplora: Some(opts.config.esplora),
         bitcoind: Some(opts.config.bitcoind),

--- a/react-native-nitro-ark/cpp/NitroArk.hpp
+++ b/react-native-nitro-ark/cpp/NitroArk.hpp
@@ -343,6 +343,7 @@ private:
     if (config.has_value()) {
       config_opts.ark = config->ark;
       config_opts.server_access_token = config->server_access_token.value_or("");
+      config_opts.user_agent = config->user_agent.value_or("");
       config_opts.esplora = config->esplora.value_or("");
       config_opts.bitcoind = config->bitcoind.value_or("");
       config_opts.bitcoind_cookie = config->bitcoind_cookie.value_or("");
@@ -369,6 +370,11 @@ public:
   }
 
   // --- Management ---
+
+  std::string getBarkVersion() override {
+    rust::String version = bark_cxx::bark_version();
+    return std::string(version.data(), version.length());
+  }
 
   std::shared_ptr<Promise<std::string>> createMnemonic() override {
     return Promise<std::string>::async([]() {

--- a/react-native-nitro-ark/cpp/generated/ark_cxx.h
+++ b/react-native-nitro-ark/cpp/generated/ark_cxx.h
@@ -1285,6 +1285,7 @@ struct CxxArkInfo final {
 struct ConfigOpts final {
   ::rust::String ark;
   ::rust::String server_access_token;
+  ::rust::String user_agent;
   ::rust::String esplora;
   ::rust::String bitcoind;
   ::rust::String bitcoind_cookie;
@@ -1574,6 +1575,8 @@ private:
 #endif // CXXBRIDGE1_STRUCT_bark_cxx$StateChangeSubscription
 
 void init_logger() noexcept;
+
+::rust::String bark_version() noexcept;
 
 ::rust::String create_mnemonic();
 

--- a/react-native-nitro-ark/example/ios/Podfile.lock
+++ b/react-native-nitro-ark/example/ios/Podfile.lock
@@ -3,7 +3,7 @@ PODS:
   - hermes-engine (250829098.0.14):
     - hermes-engine/Pre-built (= 250829098.0.14)
   - hermes-engine/Pre-built (250829098.0.14)
-  - NitroArk (0.0.131):
+  - NitroArk (0.0.132):
     - hermes-engine
     - NitroModules
     - RCTRequired
@@ -2161,7 +2161,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   FBLazyVector: b3e7ad108f0d882e30445c5527d774e3fd432f3d
   hermes-engine: 8590b6bb4d21861e2249acfb5b028da0332ceb8f
-  NitroArk: 3fedb9f2fc57b4fee97a708706e6639cb7f77280
+  NitroArk: 5e7c04d85ef676903479058498091cbbf524b847
   NitroModules: ba9ddd723ffde85412ec774827d4a80ad9864b89
   RCTDeprecation: 2a74a2c57675e64419bd89078efde81f7c1de90b
   RCTRequired: 30451112e6fef4e6f31b4e7eee0845156e35e4b0

--- a/react-native-nitro-ark/example/src/constants.ts
+++ b/react-native-nitro-ark/example/src/constants.ts
@@ -28,6 +28,7 @@ export const getWalletConfig = (mnemonic: string): BarkCreateOpts => {
     signet: false,
     bitcoin: false,
     config: {
+      user_agent: `nitro-ark-example-${Platform.OS}/0.0.1`,
       bitcoind:
         Platform.OS === 'android'
           ? 'http://192.168.4.72:18443'

--- a/react-native-nitro-ark/nitrogen/generated/shared/c++/BarkConfigOpts.hpp
+++ b/react-native-nitro-ark/nitrogen/generated/shared/c++/BarkConfigOpts.hpp
@@ -42,6 +42,7 @@ namespace margelo::nitro::nitroark {
   public:
     std::string ark     SWIFT_PRIVATE;
     std::optional<std::string> server_access_token     SWIFT_PRIVATE;
+    std::optional<std::string> user_agent     SWIFT_PRIVATE;
     std::optional<std::string> esplora     SWIFT_PRIVATE;
     std::optional<std::string> bitcoind     SWIFT_PRIVATE;
     std::optional<std::string> bitcoind_cookie     SWIFT_PRIVATE;
@@ -55,7 +56,7 @@ namespace margelo::nitro::nitroark {
 
   public:
     BarkConfigOpts() = default;
-    explicit BarkConfigOpts(std::string ark, std::optional<std::string> server_access_token, std::optional<std::string> esplora, std::optional<std::string> bitcoind, std::optional<std::string> bitcoind_cookie, std::optional<std::string> bitcoind_user, std::optional<std::string> bitcoind_pass, double vtxo_refresh_expiry_threshold, double fallback_fee_rate, double htlc_recv_claim_delta, double vtxo_exit_margin, double round_tx_required_confirmations): ark(ark), server_access_token(server_access_token), esplora(esplora), bitcoind(bitcoind), bitcoind_cookie(bitcoind_cookie), bitcoind_user(bitcoind_user), bitcoind_pass(bitcoind_pass), vtxo_refresh_expiry_threshold(vtxo_refresh_expiry_threshold), fallback_fee_rate(fallback_fee_rate), htlc_recv_claim_delta(htlc_recv_claim_delta), vtxo_exit_margin(vtxo_exit_margin), round_tx_required_confirmations(round_tx_required_confirmations) {}
+    explicit BarkConfigOpts(std::string ark, std::optional<std::string> server_access_token, std::optional<std::string> user_agent, std::optional<std::string> esplora, std::optional<std::string> bitcoind, std::optional<std::string> bitcoind_cookie, std::optional<std::string> bitcoind_user, std::optional<std::string> bitcoind_pass, double vtxo_refresh_expiry_threshold, double fallback_fee_rate, double htlc_recv_claim_delta, double vtxo_exit_margin, double round_tx_required_confirmations): ark(ark), server_access_token(server_access_token), user_agent(user_agent), esplora(esplora), bitcoind(bitcoind), bitcoind_cookie(bitcoind_cookie), bitcoind_user(bitcoind_user), bitcoind_pass(bitcoind_pass), vtxo_refresh_expiry_threshold(vtxo_refresh_expiry_threshold), fallback_fee_rate(fallback_fee_rate), htlc_recv_claim_delta(htlc_recv_claim_delta), vtxo_exit_margin(vtxo_exit_margin), round_tx_required_confirmations(round_tx_required_confirmations) {}
 
   public:
     friend bool operator==(const BarkConfigOpts& lhs, const BarkConfigOpts& rhs) = default;
@@ -73,6 +74,7 @@ namespace margelo::nitro {
       return margelo::nitro::nitroark::BarkConfigOpts(
         JSIConverter<std::string>::fromJSI(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "ark"))),
         JSIConverter<std::optional<std::string>>::fromJSI(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "server_access_token"))),
+        JSIConverter<std::optional<std::string>>::fromJSI(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "user_agent"))),
         JSIConverter<std::optional<std::string>>::fromJSI(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "esplora"))),
         JSIConverter<std::optional<std::string>>::fromJSI(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "bitcoind"))),
         JSIConverter<std::optional<std::string>>::fromJSI(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "bitcoind_cookie"))),
@@ -89,6 +91,7 @@ namespace margelo::nitro {
       jsi::Object obj(runtime);
       obj.setProperty(runtime, PropNameIDCache::get(runtime, "ark"), JSIConverter<std::string>::toJSI(runtime, arg.ark));
       obj.setProperty(runtime, PropNameIDCache::get(runtime, "server_access_token"), JSIConverter<std::optional<std::string>>::toJSI(runtime, arg.server_access_token));
+      obj.setProperty(runtime, PropNameIDCache::get(runtime, "user_agent"), JSIConverter<std::optional<std::string>>::toJSI(runtime, arg.user_agent));
       obj.setProperty(runtime, PropNameIDCache::get(runtime, "esplora"), JSIConverter<std::optional<std::string>>::toJSI(runtime, arg.esplora));
       obj.setProperty(runtime, PropNameIDCache::get(runtime, "bitcoind"), JSIConverter<std::optional<std::string>>::toJSI(runtime, arg.bitcoind));
       obj.setProperty(runtime, PropNameIDCache::get(runtime, "bitcoind_cookie"), JSIConverter<std::optional<std::string>>::toJSI(runtime, arg.bitcoind_cookie));
@@ -111,6 +114,7 @@ namespace margelo::nitro {
       }
       if (!JSIConverter<std::string>::canConvert(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "ark")))) return false;
       if (!JSIConverter<std::optional<std::string>>::canConvert(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "server_access_token")))) return false;
+      if (!JSIConverter<std::optional<std::string>>::canConvert(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "user_agent")))) return false;
       if (!JSIConverter<std::optional<std::string>>::canConvert(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "esplora")))) return false;
       if (!JSIConverter<std::optional<std::string>>::canConvert(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "bitcoind")))) return false;
       if (!JSIConverter<std::optional<std::string>>::canConvert(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "bitcoind_cookie")))) return false;

--- a/react-native-nitro-ark/nitrogen/generated/shared/c++/HybridNitroArkSpec.cpp
+++ b/react-native-nitro-ark/nitrogen/generated/shared/c++/HybridNitroArkSpec.cpp
@@ -14,6 +14,7 @@ namespace margelo::nitro::nitroark {
     HybridObject::loadHybridMethods();
     // load custom methods/properties
     registerHybrids(this, [](Prototype& prototype) {
+      prototype.registerHybridMethod("getBarkVersion", &HybridNitroArkSpec::getBarkVersion);
       prototype.registerHybridMethod("createMnemonic", &HybridNitroArkSpec::createMnemonic);
       prototype.registerHybridMethod("createWallet", &HybridNitroArkSpec::createWallet);
       prototype.registerHybridMethod("loadWallet", &HybridNitroArkSpec::loadWallet);

--- a/react-native-nitro-ark/nitrogen/generated/shared/c++/HybridNitroArkSpec.hpp
+++ b/react-native-nitro-ark/nitrogen/generated/shared/c++/HybridNitroArkSpec.hpp
@@ -142,6 +142,7 @@ namespace margelo::nitro::nitroark {
 
     public:
       // Methods
+      virtual std::string getBarkVersion() = 0;
       virtual std::shared_ptr<Promise<std::string>> createMnemonic() = 0;
       virtual std::shared_ptr<Promise<void>> createWallet(const std::string& datadir, const BarkCreateOpts& opts) = 0;
       virtual std::shared_ptr<Promise<void>> loadWallet(const std::string& datadir, const BarkCreateOpts& config) = 0;

--- a/react-native-nitro-ark/package.json
+++ b/react-native-nitro-ark/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-nitro-ark",
-  "version": "0.0.131",
+  "version": "0.0.132",
   "description": "Pure C++ Nitro Modules for Ark client",
   "source": "./src/index.tsx",
   "main": "./lib/module/index.js",

--- a/react-native-nitro-ark/src/NitroArk.nitro.ts
+++ b/react-native-nitro-ark/src/NitroArk.nitro.ts
@@ -7,6 +7,8 @@ import type { HybridObject } from 'react-native-nitro-modules';
 export interface BarkConfigOpts {
   ark: string;
   server_access_token?: string;
+  /** Client identifier sent as `x-user-agent`, formatted as `<name>/<version>`. */
+  user_agent?: string;
   esplora?: string;
   bitcoind?: string;
   bitcoind_cookie?: string;
@@ -320,6 +322,7 @@ export interface WalletStateChangeSubscription
 
 export interface NitroArk extends HybridObject<{ ios: 'c++'; android: 'c++' }> {
   // --- Management ---
+  getBarkVersion(): string;
   createMnemonic(): Promise<string>;
   createWallet(datadir: string, opts: BarkCreateOpts): Promise<void>;
   loadWallet(datadir: string, config: BarkCreateOpts): Promise<void>;

--- a/react-native-nitro-ark/src/index.tsx
+++ b/react-native-nitro-ark/src/index.tsx
@@ -195,6 +195,11 @@ function enrichExitStatus(result: NitroExitStatusResult): ExitStatusResult {
 
 // --- Management ---
 
+/** Returns the semver of the Bark wallet library compiled into the native module. */
+export function getBarkVersion(): string {
+  return NitroArkHybridObject.getBarkVersion();
+}
+
 /**
  * Creates a new BIP39 mnemonic phrase.
  * @returns A promise resolving to the mnemonic string.


### PR DESCRIPTION
## Summary

- pass an optional application user agent from TypeScript through Nitro/C++ into Bark configuration
- expose the resolved `bark-wallet` crate version through a synchronous `getBarkVersion()` API
- regenerate Nitro and CXX bridge files
- bump the package and Pod lock version to `0.0.132`

## Why

Bark now accepts a per-integrator user agent for Ark RPC attribution. Consumers also need a runtime way to report which Bark crate version was compiled into the native module.

## Impact

Applications can set values such as `someapp-android/0.0.1` in `BarkConfigOpts.user_agent`. They can call `getBarkVersion()` to retrieve the compiled Bark semver. Existing callers remain compatible because the new configuration field is optional.

## Validation

- `cargo fmt -- --check`
- `cargo test` (15 passed, 15 integration tests ignored as expected)
- `yarn prepare` (type declarations, module build, and Nitrogen generation)